### PR TITLE
Add BundleOrchestrator Helm chart with Blob Storage integration

### DIFF
--- a/deploy/charts/bundle-orchestrator/Chart.yaml
+++ b/deploy/charts/bundle-orchestrator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: bundle-orchestrator
+description: SignalBeam BundleOrchestrator - bundle management, versioning, and rollout orchestration
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/charts/bundle-orchestrator/README.md
+++ b/deploy/charts/bundle-orchestrator/README.md
@@ -1,0 +1,70 @@
+# BundleOrchestrator Helm Chart
+
+Deploys the SignalBeam BundleOrchestrator service — bundle management, versioning, and rollout orchestration with Azure Blob Storage integration.
+
+## Quick Start
+
+```bash
+helm install bundle-orchestrator deploy/charts/bundle-orchestrator -n signalbeam --create-namespace
+
+# With environment-specific values
+helm install bundle-orchestrator deploy/charts/bundle-orchestrator -n signalbeam \
+  -f deploy/charts/bundle-orchestrator/values-dev.yaml
+```
+
+## Environment Values
+
+| File | Replicas | HPA | Workload Identity | Ingress |
+|------|----------|-----|-------------------|---------|
+| `values.yaml` | 2 | 2-10 | off | off |
+| `values-dev.yaml` | 1 | off | off | off |
+| `values-staging.yaml` | 2 | 2-5 | on | off |
+| `values-prod.yaml` | 3 | 3-10 | on | on |
+
+## Prerequisites
+
+Create Kubernetes secrets before installing:
+
+```bash
+kubectl create secret generic bundle-orchestrator-db -n signalbeam \
+  --from-literal=connection-string="Host=postgres;Database=signalbeam_bundles;Username=app;Password=secret"
+
+kubectl create secret generic bundle-orchestrator-blob -n signalbeam \
+  --from-literal=service-uri="https://signalbeam.blob.core.windows.net"
+```
+
+### Azure Workload Identity (Staging/Production)
+
+The BundleOrchestrator uses Azure Workload Identity to access Blob Storage without storing credentials. Set `workloadIdentity.enabled=true` and provide the managed identity `clientId`:
+
+```bash
+helm install bundle-orchestrator deploy/charts/bundle-orchestrator -n signalbeam \
+  -f deploy/charts/bundle-orchestrator/values-prod.yaml \
+  --set workloadIdentity.clientId=<your-managed-identity-client-id>
+```
+
+The ServiceAccount will be annotated with `azure.workload.identity/client-id` and pods labeled with `azure.workload.identity/use: "true"`.
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `image.repository` | `ghcr.io/signalbeam-io/bundle-orchestrator` | Container image |
+| `image.tag` | `appVersion` | Image tag |
+| `service.port` | `80` | Service port |
+| `service.targetPort` | `8080` | Container port |
+| `autoscaling.minReplicas` | `2` | Min HPA replicas |
+| `autoscaling.maxReplicas` | `10` | Max HPA replicas |
+| `workloadIdentity.enabled` | `false` | Azure Workload Identity |
+| `workloadIdentity.clientId` | `""` | Managed identity client ID |
+| `config.AzureBlobStorage__ContainerName` | `signalbeam-bundles` | Blob container name |
+| `serviceMonitor.enabled` | `true` | Prometheus ServiceMonitor |
+
+## Upgrade / Uninstall
+
+```bash
+helm upgrade bundle-orchestrator deploy/charts/bundle-orchestrator -n signalbeam \
+  -f deploy/charts/bundle-orchestrator/values-prod.yaml
+
+helm uninstall bundle-orchestrator -n signalbeam
+```

--- a/deploy/charts/bundle-orchestrator/templates/_helpers.tpl
+++ b/deploy/charts/bundle-orchestrator/templates/_helpers.tpl
@@ -1,0 +1,58 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bundle-orchestrator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "bundle-orchestrator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bundle-orchestrator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bundle-orchestrator.labels" -}}
+helm.sh/chart: {{ include "bundle-orchestrator.chart" . }}
+{{ include "bundle-orchestrator.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bundle-orchestrator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bundle-orchestrator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bundle-orchestrator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bundle-orchestrator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/bundle-orchestrator/templates/configmap.yaml
+++ b/deploy/charts/bundle-orchestrator/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bundle-orchestrator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bundle-orchestrator.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/deploy/charts/bundle-orchestrator/templates/deployment.yaml
+++ b/deploy/charts/bundle-orchestrator/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bundle-orchestrator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bundle-orchestrator.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "bundle-orchestrator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "bundle-orchestrator.labels" . | nindent 8 }}
+        {{- if .Values.workloadIdentity.enabled }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "bundle-orchestrator.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "bundle-orchestrator.fullname" . }}
+          env:
+            {{- range $secret := .Values.secrets }}
+            {{- range $envVar, $secretKey := $secret.envMapping }}
+            - name: {{ $envVar }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secret.secretName }}
+                  key: {{ $secretKey }}
+            {{- end }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/bundle-orchestrator/templates/hpa.yaml
+++ b/deploy/charts/bundle-orchestrator/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bundle-orchestrator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bundle-orchestrator.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bundle-orchestrator.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/bundle-orchestrator/templates/ingress.yaml
+++ b/deploy/charts/bundle-orchestrator/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "bundle-orchestrator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bundle-orchestrator.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "bundle-orchestrator.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/bundle-orchestrator/templates/service.yaml
+++ b/deploy/charts/bundle-orchestrator/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bundle-orchestrator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bundle-orchestrator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "bundle-orchestrator.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/bundle-orchestrator/templates/serviceaccount.yaml
+++ b/deploy/charts/bundle-orchestrator/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bundle-orchestrator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bundle-orchestrator.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.workloadIdentity.enabled }}
+    azure.workload.identity/client-id: {{ .Values.workloadIdentity.clientId | quote }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/bundle-orchestrator/templates/servicemonitor.yaml
+++ b/deploy/charts/bundle-orchestrator/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "bundle-orchestrator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bundle-orchestrator.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "bundle-orchestrator.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/deploy/charts/bundle-orchestrator/values-dev.yaml
+++ b/deploy/charts/bundle-orchestrator/values-dev.yaml
@@ -1,0 +1,24 @@
+replicaCount: 1
+
+image:
+  tag: "latest"
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: false
+
+config:
+  ASPNETCORE_ENVIRONMENT: Development
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.signalbeam:4317"
+  NATS__Url: "nats://nats.signalbeam:4222"
+  AzureBlobStorage__ContainerName: "signalbeam-bundles"
+
+serviceMonitor:
+  enabled: false

--- a/deploy/charts/bundle-orchestrator/values-prod.yaml
+++ b/deploy/charts/bundle-orchestrator/values-prod.yaml
@@ -1,0 +1,41 @@
+replicaCount: 3
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 75
+
+config:
+  ASPNETCORE_ENVIRONMENT: Production
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.signalbeam:4317"
+  NATS__Url: "nats://nats.signalbeam:4222"
+  AzureBlobStorage__ContainerName: "signalbeam-bundles"
+
+workloadIdentity:
+  enabled: true
+  clientId: ""
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: api.signalbeam.io
+      paths:
+        - path: /api/bundles
+          pathType: Prefix
+  tls:
+    - secretName: signalbeam-tls
+      hosts:
+        - api.signalbeam.io

--- a/deploy/charts/bundle-orchestrator/values-staging.yaml
+++ b/deploy/charts/bundle-orchestrator/values-staging.yaml
@@ -1,0 +1,25 @@
+replicaCount: 2
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 75
+
+config:
+  ASPNETCORE_ENVIRONMENT: Staging
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.signalbeam:4317"
+  NATS__Url: "nats://nats.signalbeam:4222"
+  AzureBlobStorage__ContainerName: "signalbeam-bundles-staging"
+
+workloadIdentity:
+  enabled: true
+  clientId: ""

--- a/deploy/charts/bundle-orchestrator/values.yaml
+++ b/deploy/charts/bundle-orchestrator/values.yaml
@@ -1,0 +1,97 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/signalbeam-io/bundle-orchestrator
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: bundle-orchestrator.signalbeam.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 75
+  targetMemoryUtilizationPercentage: 80
+
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 20
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Azure Workload Identity (required for Blob Storage access)
+workloadIdentity:
+  enabled: false
+  clientId: ""
+
+# Environment variables from ConfigMap
+config:
+  ASPNETCORE_ENVIRONMENT: Production
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.signalbeam:4317"
+  NATS__Url: "nats://nats.signalbeam:4222"
+  AzureBlobStorage__ContainerName: "signalbeam-bundles"
+
+# Secret references
+secrets:
+  - secretName: bundle-orchestrator-db
+    envMapping:
+      ConnectionStrings__DefaultConnection: connection-string
+  - secretName: bundle-orchestrator-blob
+    envMapping:
+      AzureBlobStorage__ServiceUri: service-uri
+
+# ServiceMonitor for Prometheus
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  path: /metrics
+  labels: {}


### PR DESCRIPTION
## Summary

- Add Helm chart for BundleOrchestrator service deployment to Kubernetes
- Configure Deployment with Azure Workload Identity for Blob Storage access
- Add HPA (2-10 replicas), ClusterIP Service, ServiceMonitor for Prometheus, and Ingress
- Create environment-specific values for dev, staging, and production
- Include chart documentation with Workload Identity setup instructions

Closes #148

## Test plan

- [x] `helm lint` passes with no errors
- [x] `helm template` renders correctly for all environment values (dev/staging/prod)
- [x] `helm install --dry-run` validates against local Kubernetes cluster
- [x] Full `helm install` to local cluster creates all expected resources
- [x] `helm uninstall` cleans up all resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)