### PR TITLE
Add TelemetryProcessor Helm chart for HA metrics ingestion

### DIFF
--- a/deploy/charts/telemetry-processor/Chart.yaml
+++ b/deploy/charts/telemetry-processor/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: telemetry-processor
+description: SignalBeam TelemetryProcessor - metrics ingestion, heartbeat processing, alerting, and health monitoring
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/charts/telemetry-processor/README.md
+++ b/deploy/charts/telemetry-processor/README.md
@@ -1,0 +1,51 @@
+# TelemetryProcessor Helm Chart
+
+Deploys the SignalBeam TelemetryProcessor service — metrics ingestion, heartbeat processing, device health monitoring, and alerting via NATS.
+
+## Quick Start
+
+```bash
+helm install telemetry-processor deploy/charts/telemetry-processor -n signalbeam --create-namespace
+
+# With environment-specific values
+helm install telemetry-processor deploy/charts/telemetry-processor -n signalbeam \
+  -f deploy/charts/telemetry-processor/values-dev.yaml
+```
+
+## Environment Values
+
+| File | Replicas | HPA | Scrape Interval |
+|------|----------|-----|-----------------|
+| `values.yaml` | 3 | 3-15 | 15s |
+| `values-dev.yaml` | 1 | off | disabled |
+| `values-staging.yaml` | 3 | 3-8 | 15s |
+| `values-prod.yaml` | 3 | 3-15 | 10s |
+
+## Prerequisites
+
+```bash
+kubectl create secret generic telemetry-processor-db -n signalbeam \
+  --from-literal=connection-string="Host=postgres;Database=signalbeam_telemetry;Username=app;Password=secret"
+
+kubectl create secret generic telemetry-processor-nats -n signalbeam \
+  --from-literal=token="nats-auth-token"
+```
+
+## NATS Configuration
+
+The TelemetryProcessor subscribes to NATS subjects for heartbeats and metrics. Configure the NATS URL via `config.NATS__Url` and authentication token via the `telemetry-processor-nats` secret.
+
+## Scaling
+
+This service is designed for high throughput. Default HPA scales 3-15 replicas based on CPU (65-70%) and memory (75-80%). Production uses higher resource limits (2 CPU, 1Gi) to handle metric ingestion spikes.
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `config.NATS__Url` | `nats://nats.signalbeam:4222` | NATS server URL |
+| `config.DeviceStatusMonitor__CheckIntervalSeconds` | `30` | Status check interval |
+| `config.DeviceStatusMonitor__OfflineThresholdSeconds` | `120` | Offline threshold |
+| `config.MetricsAggregation__IntervalSeconds` | `60` | Aggregation interval |
+| `config.HealthMonitor__CheckIntervalSeconds` | `30` | Health check interval |
+| `serviceMonitor.interval` | `15s` | Prometheus scrape interval |

--- a/deploy/charts/telemetry-processor/templates/_helpers.tpl
+++ b/deploy/charts/telemetry-processor/templates/_helpers.tpl
@@ -1,0 +1,58 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telemetry-processor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "telemetry-processor.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telemetry-processor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "telemetry-processor.labels" -}}
+helm.sh/chart: {{ include "telemetry-processor.chart" . }}
+{{ include "telemetry-processor.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "telemetry-processor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "telemetry-processor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "telemetry-processor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "telemetry-processor.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/telemetry-processor/templates/configmap.yaml
+++ b/deploy/charts/telemetry-processor/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "telemetry-processor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telemetry-processor.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/deploy/charts/telemetry-processor/templates/deployment.yaml
+++ b/deploy/charts/telemetry-processor/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "telemetry-processor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telemetry-processor.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "telemetry-processor.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "telemetry-processor.labels" . | nindent 8 }}
+        {{- if .Values.workloadIdentity.enabled }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "telemetry-processor.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "telemetry-processor.fullname" . }}
+          env:
+            {{- range $secret := .Values.secrets }}
+            {{- range $envVar, $secretKey := $secret.envMapping }}
+            - name: {{ $envVar }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secret.secretName }}
+                  key: {{ $secretKey }}
+            {{- end }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/telemetry-processor/templates/hpa.yaml
+++ b/deploy/charts/telemetry-processor/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "telemetry-processor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telemetry-processor.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "telemetry-processor.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/telemetry-processor/templates/service.yaml
+++ b/deploy/charts/telemetry-processor/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telemetry-processor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telemetry-processor.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "telemetry-processor.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/telemetry-processor/templates/serviceaccount.yaml
+++ b/deploy/charts/telemetry-processor/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "telemetry-processor.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telemetry-processor.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.workloadIdentity.enabled }}
+    azure.workload.identity/client-id: {{ .Values.workloadIdentity.clientId | quote }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/telemetry-processor/templates/servicemonitor.yaml
+++ b/deploy/charts/telemetry-processor/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "telemetry-processor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telemetry-processor.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "telemetry-processor.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/deploy/charts/telemetry-processor/values-dev.yaml
+++ b/deploy/charts/telemetry-processor/values-dev.yaml
@@ -1,0 +1,27 @@
+replicaCount: 1
+
+image:
+  tag: "latest"
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: false
+
+config:
+  ASPNETCORE_ENVIRONMENT: Development
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.signalbeam:4317"
+  NATS__Url: "nats://nats.signalbeam:4222"
+  DeviceStatusMonitor__CheckIntervalSeconds: "30"
+  DeviceStatusMonitor__OfflineThresholdSeconds: "120"
+  MetricsAggregation__IntervalSeconds: "60"
+  HealthMonitor__CheckIntervalSeconds: "30"
+
+serviceMonitor:
+  enabled: false

--- a/deploy/charts/telemetry-processor/values-prod.yaml
+++ b/deploy/charts/telemetry-processor/values-prod.yaml
@@ -1,0 +1,32 @@
+replicaCount: 3
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: "1Gi"
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 15
+  targetCPUUtilizationPercentage: 65
+  targetMemoryUtilizationPercentage: 75
+
+config:
+  ASPNETCORE_ENVIRONMENT: Production
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.signalbeam:4317"
+  NATS__Url: "nats://nats.signalbeam:4222"
+  DeviceStatusMonitor__CheckIntervalSeconds: "15"
+  DeviceStatusMonitor__OfflineThresholdSeconds: "90"
+  MetricsAggregation__IntervalSeconds: "30"
+  HealthMonitor__CheckIntervalSeconds: "15"
+
+workloadIdentity:
+  enabled: true
+  clientId: ""
+
+serviceMonitor:
+  interval: 10s

--- a/deploy/charts/telemetry-processor/values-staging.yaml
+++ b/deploy/charts/telemetry-processor/values-staging.yaml
@@ -1,0 +1,28 @@
+replicaCount: 3
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 8
+  targetCPUUtilizationPercentage: 70
+
+config:
+  ASPNETCORE_ENVIRONMENT: Staging
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.signalbeam:4317"
+  NATS__Url: "nats://nats.signalbeam:4222"
+  DeviceStatusMonitor__CheckIntervalSeconds: "30"
+  DeviceStatusMonitor__OfflineThresholdSeconds: "120"
+  MetricsAggregation__IntervalSeconds: "60"
+  HealthMonitor__CheckIntervalSeconds: "30"
+
+workloadIdentity:
+  enabled: true
+  clientId: ""

--- a/deploy/charts/telemetry-processor/values.yaml
+++ b/deploy/charts/telemetry-processor/values.yaml
@@ -1,0 +1,100 @@
+replicaCount: 3
+
+image:
+  repository: ghcr.io/signalbeam-io/telemetry-processor
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 15
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 20
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Azure Workload Identity
+workloadIdentity:
+  enabled: false
+  clientId: ""
+
+# Environment variables from ConfigMap
+config:
+  ASPNETCORE_ENVIRONMENT: Production
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.signalbeam:4317"
+  # NATS connection
+  NATS__Url: "nats://nats.signalbeam:4222"
+  # Device status monitor
+  DeviceStatusMonitor__CheckIntervalSeconds: "30"
+  DeviceStatusMonitor__OfflineThresholdSeconds: "120"
+  # Metrics aggregation
+  MetricsAggregation__IntervalSeconds: "60"
+  # Health monitor
+  HealthMonitor__CheckIntervalSeconds: "30"
+
+# Secret references
+secrets:
+  - secretName: telemetry-processor-db
+    envMapping:
+      ConnectionStrings__DefaultConnection: connection-string
+  - secretName: telemetry-processor-nats
+    envMapping:
+      NATS__Token: token
+
+# ServiceMonitor for Prometheus
+serviceMonitor:
+  enabled: true
+  interval: 15s
+  path: /metrics
+  labels: {}


### PR DESCRIPTION
## Summary

- Add Helm chart for TelemetryProcessor service with 3+ replicas for high availability
- Configure NATS connection settings (URL via ConfigMap, auth token via Secret)
- Add HPA (3-15 replicas), ServiceMonitor with 15s scrape interval, and configurable monitoring thresholds
- Create environment-specific values with production-tuned resources (2 CPU, 1Gi) and tighter check intervals

Closes #152

## Test plan

- [x] `helm lint` passes with no errors
- [x] `helm template` renders correctly for all environment values (dev/staging/prod)
- [x] `helm install --dry-run` validates against local Kubernetes cluster
- [x] HPA configured with 3 min replicas for HA requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)