### PR TITLE
Add frontend Dockerfile and Helm chart for K8s deployment

### DIFF
--- a/deploy/charts/web/Chart.yaml
+++ b/deploy/charts/web/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: web
+description: SignalBeam Web UI - React SPA served via nginx
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/charts/web/README.md
+++ b/deploy/charts/web/README.md
@@ -1,0 +1,51 @@
+# Web UI Helm Chart
+
+Deploys the SignalBeam Web UI — a React SPA served via nginx with API proxy to the gateway.
+
+## Quick Start
+
+```bash
+# Build the Docker image
+cd web && docker build -t ghcr.io/signalbeam-io/web:latest .
+
+# Deploy
+helm install web deploy/charts/web -n signalbeam --create-namespace
+```
+
+## Environment Values
+
+| File | Replicas | HPA | Ingress |
+|------|----------|-----|---------|
+| `values.yaml` | 2 | 2-8 | off |
+| `values-dev.yaml` | 1 | off | off |
+| `values-staging.yaml` | 2 | 2-4 | on |
+| `values-prod.yaml` | 2 | 2-8 | on + TLS |
+
+## How It Works
+
+1. **Build stage** — `npm run build` produces static assets in `/dist`
+2. **Runtime** — nginx serves the SPA with:
+   - SPA fallback (`try_files $uri /index.html`)
+   - Gzip compression for JS/CSS/JSON
+   - CDN-friendly caching (`Cache-Control: public, immutable` for hashed assets, no-cache for `index.html`)
+   - Security headers (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection)
+   - `/api/` proxy to the API Gateway (configurable via `API_URL` env var)
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `apiUrl` | `http://api-gateway.signalbeam` | Backend API Gateway URL for nginx proxy |
+| `service.port` | `80` | Service port |
+| `ingress.enabled` | `false` | Enable Ingress |
+
+The `API_URL` environment variable is injected at container startup via nginx's `envsubst` template mechanism — no rebuild needed to change the backend URL.
+
+## Upgrade / Uninstall
+
+```bash
+helm upgrade web deploy/charts/web -n signalbeam \
+  -f deploy/charts/web/values-prod.yaml
+
+helm uninstall web -n signalbeam
+```

--- a/deploy/charts/web/templates/_helpers.tpl
+++ b/deploy/charts/web/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{- define "web.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "web.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "web.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "web.labels" -}}
+helm.sh/chart: {{ include "web.chart" . }}
+{{ include "web.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "web.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "web.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "web.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "web.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/web/templates/deployment.yaml
+++ b/deploy/charts/web/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "web.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "web.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "web.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "web.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            - name: API_URL
+              value: {{ .Values.apiUrl | quote }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/web/templates/hpa.yaml
+++ b/deploy/charts/web/templates/hpa.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "web.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "web.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/web/templates/ingress.yaml
+++ b/deploy/charts/web/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "web.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "web.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/web/templates/service.yaml
+++ b/deploy/charts/web/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "web.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "web.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/web/templates/serviceaccount.yaml
+++ b/deploy/charts/web/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "web.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "web.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/web/values-dev.yaml
+++ b/deploy/charts/web/values-dev.yaml
@@ -1,0 +1,17 @@
+replicaCount: 1
+
+image:
+  tag: "latest"
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 64Mi
+
+autoscaling:
+  enabled: false
+
+apiUrl: "http://api-gateway.signalbeam"

--- a/deploy/charts/web/values-prod.yaml
+++ b/deploy/charts/web/values-prod.yaml
@@ -1,0 +1,32 @@
+replicaCount: 2
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 64Mi
+  limits:
+    cpu: 300m
+    memory: 128Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 8
+  targetCPUUtilizationPercentage: 70
+
+apiUrl: "http://api-gateway.signalbeam"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: app.signalbeam.io
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: signalbeam-web-tls
+      hosts:
+        - app.signalbeam.io

--- a/deploy/charts/web/values-staging.yaml
+++ b/deploy/charts/web/values-staging.yaml
@@ -1,0 +1,18 @@
+replicaCount: 2
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 75
+
+apiUrl: "http://api-gateway.signalbeam"
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: app-staging.signalbeam.io
+      paths:
+        - path: /
+          pathType: Prefix

--- a/deploy/charts/web/values.yaml
+++ b/deploy/charts/web/values.yaml
@@ -1,0 +1,77 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/signalbeam-io/web
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: app.signalbeam.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 8
+  targetCPUUtilizationPercentage: 75
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 15
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 10
+  failureThreshold: 3
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# API Gateway URL for nginx proxy_pass
+apiUrl: "http://api-gateway.signalbeam"
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  path: /metrics
+  labels: {}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -18,11 +18,14 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine
 
-# Copy custom nginx config
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Copy custom nginx config template
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Default API URL (overridden via env var in Kubernetes)
+ENV API_URL=http://api-gateway:80
 
 # Expose port 80
 EXPOSE 80
@@ -31,5 +34,5 @@ EXPOSE 80
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost/ || exit 1
 
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"]
+# nginx:alpine uses docker-entrypoint.sh which runs envsubst on /etc/nginx/templates/*.template
+# and outputs to /etc/nginx/conf.d/, then starts nginx

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -26,9 +26,16 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # API proxy (optional - if API is on different domain)
+    # Do not cache index.html (ensure latest app version)
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
+    # API proxy to gateway (used when frontend and API share the same domain)
     location /api/ {
-        proxy_pass http://device-manager:8080/api/;
+        proxy_pass ${API_URL}/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Summary

- Update multi-stage Dockerfile to use nginx `envsubst` templates for runtime `API_URL` configuration
- Update nginx.conf with no-cache headers for `index.html`, immutable CDN caching for hashed assets, and configurable API proxy to the gateway
- Add `web` Helm chart with Deployment, Service, Ingress, HPA (2-8 replicas), and environment-specific values for dev/staging/prod
- Include deployment documentation

Closes #165

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders correctly for all environments (dev/staging/prod)
- [x] `helm install --dry-run` validates
- [x] nginx config has SPA fallback, gzip, security headers, CDN caching
- [x] `API_URL` env var injected at runtime via envsubst (no rebuild needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)