### PR TITLE
Deploy AKS cluster services: ingress, TLS, monitoring, observability

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -4,7 +4,7 @@ Terraform + Terragrunt configuration for provisioning the SignalBeam Edge dev en
 
 ## Architecture
 
-11 Terraform modules wired together by Terragrunt with the following dependency graph:
+17 Terraform modules wired together by Terragrunt with the following dependency graph:
 
 ```
 Phase 1: resource-group
@@ -12,7 +12,9 @@ Phase 2: networking, monitoring, container-registry, managed-identity, dns  (par
 Phase 3: key-vault, storage  (depend on networking + managed-identity)
 Phase 4: postgresql  (depends on networking + key-vault)
 Phase 5: aks-cluster  (depends on networking + ACR + monitoring + managed-identity + key-vault)
-Phase 6: nats  (depends on aks-cluster — deploys into K8s via Helm)
+Phase 6: cert-manager, ingress-nginx, nats, kube-prometheus-stack  (depend on aks-cluster)
+Phase 7: loki, tempo  (depend on kube-prometheus-stack for monitoring namespace)
+Phase 8: otel-collector  (depends on loki + tempo + kube-prometheus-stack)
 ```
 
 ## Resources Provisioned
@@ -30,6 +32,12 @@ Phase 6: nats  (depends on aks-cluster — deploys into K8s via Helm)
 | dns | DNS zone `dev.signalbeam.io` | ~$0.50/mo |
 | aks-cluster | AKS 1x B4ms, workload identity, Calico, Container Insights | ~$120/mo |
 | nats | NATS 3-node cluster with JetStream (10Gi file storage), Prometheus exporter | ~$0 (runs on AKS) |
+| cert-manager | TLS certificate management with Let's Encrypt ClusterIssuers | ~$0 (runs on AKS) |
+| ingress-nginx | NGINX Ingress Controller (2 replicas) with Azure LoadBalancer | ~$0 (runs on AKS) |
+| kube-prometheus-stack | Prometheus Operator, Prometheus (20Gi), Grafana (5Gi), AlertManager | ~$0 (runs on AKS) |
+| loki | Log aggregation, single-binary mode (10Gi) | ~$0 (runs on AKS) |
+| tempo | Distributed tracing backend (10Gi) | ~$0 (runs on AKS) |
+| otel-collector | OpenTelemetry Collector (2 replicas), routes to Tempo/Prometheus/Loki | ~$0 (runs on AKS) |
 | **Total** | | **~$142/mo** |
 
 ## Prerequisites
@@ -166,6 +174,23 @@ kubectl -n signalbeam exec -it nats-0 -- nats server check jetstream
 
 # JetStream streams created
 kubectl -n signalbeam exec -it nats-0 -- nats stream ls
+
+# Ingress controller running with external IP
+kubectl -n ingress-nginx get svc ingress-nginx-controller
+
+# cert-manager ready
+kubectl -n cert-manager get pods
+kubectl get clusterissuer
+
+# Prometheus, Grafana, AlertManager running
+kubectl -n monitoring get pods
+
+# Loki and Tempo running
+kubectl -n monitoring get pods -l app.kubernetes.io/name=loki
+kubectl -n monitoring get pods -l app.kubernetes.io/name=tempo
+
+# OTEL Collector running
+kubectl -n signalbeam get pods -l app.kubernetes.io/name=otel-collector
 ```
 
 ## Ongoing Changes
@@ -223,7 +248,13 @@ infra/
 │   ├── storage/                         # Blob account + containers
 │   ├── dns/                             # Azure DNS zone
 │   ├── aks-cluster/                     # AKS with workload identity
-│   └── nats/                            # NATS cluster with JetStream (Helm)
+│   ├── nats/                            # NATS cluster with JetStream (Helm)
+│   ├── cert-manager/                    # TLS cert management + Let's Encrypt
+│   ├── ingress-nginx/                   # NGINX Ingress Controller
+│   ├── kube-prometheus-stack/           # Prometheus + Grafana + AlertManager
+│   ├── loki/                            # Log aggregation
+│   ├── tempo/                           # Distributed tracing
+│   └── otel-collector/                  # OpenTelemetry Collector
 └── terragrunt/
     ├── terragrunt.hcl                   # Root config: backend, provider, inputs
     └── dev/
@@ -238,7 +269,13 @@ infra/
         ├── storage/terragrunt.hcl
         ├── dns/terragrunt.hcl
         ├── aks-cluster/terragrunt.hcl
-        └── nats/terragrunt.hcl
+        ├── nats/terragrunt.hcl
+        ├── cert-manager/terragrunt.hcl
+        ├── ingress-nginx/terragrunt.hcl
+        ├── kube-prometheus-stack/terragrunt.hcl
+        ├── loki/terragrunt.hcl
+        ├── tempo/terragrunt.hcl
+        └── otel-collector/terragrunt.hcl
 ```
 
 ## NATS Architecture
@@ -275,3 +312,42 @@ signalbeam.telemetry.metrics.<deviceId>      # → TELEMETRY_METRICS stream
 ```
 
 Heartbeats and commands use Core NATS (ephemeral pub/sub, request/reply). All other subjects are persisted in JetStream streams for reliable delivery and replay.
+
+## Ingress & TLS
+
+- **Ingress Controller:** NGINX (`ingress-nginx`) with Azure LoadBalancer, 2 replicas
+- **TLS:** cert-manager with Let's Encrypt ClusterIssuers (`letsencrypt-prod`, `letsencrypt-staging`)
+- **DNS01 Validation:** Azure DNS via workload identity (federated credentials provisioned in AKS module)
+- **IngressClass:** `nginx` (set as default)
+
+All production Helm values reference `ingressClassName: nginx` and `cert-manager.io/cluster-issuer: letsencrypt-prod`.
+
+## Observability Stack
+
+The observability pipeline collects traces, metrics, and logs from all microservices:
+
+```
+Microservices → OTEL Collector → Tempo (traces)
+                               → Prometheus (metrics)
+                               → Loki (logs)
+                               → Grafana (dashboards)
+```
+
+### Components
+
+| Component | Namespace | Endpoint | Purpose |
+|-----------|-----------|----------|---------|
+| OTEL Collector | `signalbeam` | `otel-collector.signalbeam:4317` (gRPC) | Receives OTLP telemetry, routes to backends |
+| Prometheus | `monitoring` | `kube-prometheus-stack-prometheus:9090` | Metrics storage, ServiceMonitor scraping |
+| Grafana | `monitoring` | `kube-prometheus-stack-grafana:80` | Dashboards (Loki + Tempo + Prometheus datasources pre-configured) |
+| Loki | `monitoring` | `loki.monitoring:3100` | Log aggregation (single-binary, 7d retention) |
+| Tempo | `monitoring` | `tempo.monitoring:3100` | Distributed tracing (7d retention) |
+| AlertManager | `monitoring` | `kube-prometheus-stack-alertmanager:9093` | Alert routing |
+
+### Data Flow
+
+- **Traces:** Microservices → OTLP gRPC → OTEL Collector → Tempo
+- **Metrics:** OTEL Collector → Prometheus remote write; Prometheus also scrapes ServiceMonitors directly
+- **Logs:** Microservices → OTLP gRPC → OTEL Collector → Loki
+
+All microservice Helm charts define ServiceMonitors that Prometheus Operator auto-discovers.

--- a/infra/terraform/modules/cert-manager/main.tf
+++ b/infra/terraform/modules/cert-manager/main.tf
@@ -1,0 +1,149 @@
+# Deploy cert-manager with Let's Encrypt ClusterIssuers for TLS certificate management.
+
+locals {
+  parsed_kubeconfig = yamldecode(var.kube_config_raw)
+
+  kube_config = {
+    host                   = local.parsed_kubeconfig.clusters[0].cluster.server
+    client_certificate     = base64decode(local.parsed_kubeconfig.users[0].user.client-certificate-data)
+    client_key             = base64decode(local.parsed_kubeconfig.users[0].user.client-key-data)
+    cluster_ca_certificate = base64decode(local.parsed_kubeconfig.clusters[0].cluster.certificate-authority-data)
+  }
+
+  common_labels = {
+    "app.kubernetes.io/managed-by" = "terraform"
+    "signalbeam.io/environment"    = var.environment
+    "signalbeam.io/project"        = var.project
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.kube_config.host
+    client_certificate     = local.kube_config.client_certificate
+    client_key             = local.kube_config.client_key
+    cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.kube_config.host
+  client_certificate     = local.kube_config.client_certificate
+  client_key             = local.kube_config.client_key
+  cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+}
+
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = var.chart_version
+  namespace        = "cert-manager"
+  create_namespace = true
+
+  set {
+    name  = "crds.enabled"
+    value = "true"
+  }
+
+  # Workload identity for Azure DNS01 solver
+  set {
+    name  = "podLabels.azure\\.workload\\.identity/use"
+    value = "true"
+  }
+
+  set {
+    name  = "serviceAccount.labels.azure\\.workload\\.identity/use"
+    value = "true"
+  }
+
+  set {
+    name  = "serviceAccount.annotations.azure\\.workload\\.identity/client-id"
+    value = var.workload_identity_client_id
+  }
+
+  # Prometheus monitoring
+  set {
+    name  = "prometheus.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "prometheus.servicemonitor.enabled"
+    value = "true"
+  }
+
+  timeout = 600
+}
+
+# ClusterIssuer for Let's Encrypt production
+resource "kubernetes_manifest" "letsencrypt_prod" {
+  manifest = {
+    apiVersion = "cert-manager.io/v1"
+    kind       = "ClusterIssuer"
+    metadata = {
+      name   = "letsencrypt-prod"
+      labels = local.common_labels
+    }
+    spec = {
+      acme = {
+        server = "https://acme-v02.api.letsencrypt.org/directory"
+        email  = var.acme_email
+        privateKeySecretRef = {
+          name = "letsencrypt-prod-key"
+        }
+        solvers = [{
+          dns01 = {
+            azureDNS = {
+              hostedZoneName    = var.dns_zone_name
+              resourceGroupName = var.dns_zone_resource_group
+              subscriptionID    = "" # Uses workload identity
+              environment       = "AzurePublicCloud"
+              managedIdentity = {
+                clientID = var.workload_identity_client_id
+              }
+            }
+          }
+        }]
+      }
+    }
+  }
+
+  depends_on = [helm_release.cert_manager]
+}
+
+# ClusterIssuer for Let's Encrypt staging (for testing)
+resource "kubernetes_manifest" "letsencrypt_staging" {
+  manifest = {
+    apiVersion = "cert-manager.io/v1"
+    kind       = "ClusterIssuer"
+    metadata = {
+      name   = "letsencrypt-staging"
+      labels = local.common_labels
+    }
+    spec = {
+      acme = {
+        server = "https://acme-staging-v02.api.letsencrypt.org/directory"
+        email  = var.acme_email
+        privateKeySecretRef = {
+          name = "letsencrypt-staging-key"
+        }
+        solvers = [{
+          dns01 = {
+            azureDNS = {
+              hostedZoneName    = var.dns_zone_name
+              resourceGroupName = var.dns_zone_resource_group
+              subscriptionID    = ""
+              environment       = "AzurePublicCloud"
+              managedIdentity = {
+                clientID = var.workload_identity_client_id
+              }
+            }
+          }
+        }]
+      }
+    }
+  }
+
+  depends_on = [helm_release.cert_manager]
+}

--- a/infra/terraform/modules/cert-manager/outputs.tf
+++ b/infra/terraform/modules/cert-manager/outputs.tf
@@ -1,0 +1,14 @@
+output "namespace" {
+  description = "Namespace where cert-manager is deployed"
+  value       = helm_release.cert_manager.namespace
+}
+
+output "cluster_issuer_prod" {
+  description = "Name of the production ClusterIssuer"
+  value       = "letsencrypt-prod"
+}
+
+output "cluster_issuer_staging" {
+  description = "Name of the staging ClusterIssuer"
+  value       = "letsencrypt-staging"
+}

--- a/infra/terraform/modules/cert-manager/variables.tf
+++ b/infra/terraform/modules/cert-manager/variables.tf
@@ -1,0 +1,54 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "project" {
+  description = "Project prefix for resource naming"
+  type        = string
+  default     = "sb"
+}
+
+variable "kube_config_raw" {
+  description = "Raw kubeconfig for the AKS cluster"
+  type        = string
+  sensitive   = true
+}
+
+variable "chart_version" {
+  description = "cert-manager Helm chart version"
+  type        = string
+  default     = "1.16.3"
+}
+
+variable "workload_identity_client_id" {
+  description = "Azure workload identity client ID for DNS01 solver"
+  type        = string
+}
+
+variable "dns_zone_name" {
+  description = "Azure DNS zone name for ACME DNS01 validation"
+  type        = string
+}
+
+variable "dns_zone_resource_group" {
+  description = "Resource group containing the Azure DNS zone"
+  type        = string
+}
+
+variable "acme_email" {
+  description = "Email address for Let's Encrypt ACME registration"
+  type        = string
+  default     = "platform@signalbeam.io"
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/cert-manager/versions.tf
+++ b/infra/terraform/modules/cert-manager/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.15"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.33"
+    }
+  }
+}

--- a/infra/terraform/modules/ingress-nginx/main.tf
+++ b/infra/terraform/modules/ingress-nginx/main.tf
@@ -1,0 +1,100 @@
+# Deploy NGINX Ingress Controller for external traffic routing.
+
+locals {
+  parsed_kubeconfig = yamldecode(var.kube_config_raw)
+
+  kube_config = {
+    host                   = local.parsed_kubeconfig.clusters[0].cluster.server
+    client_certificate     = base64decode(local.parsed_kubeconfig.users[0].user.client-certificate-data)
+    client_key             = base64decode(local.parsed_kubeconfig.users[0].user.client-key-data)
+    cluster_ca_certificate = base64decode(local.parsed_kubeconfig.clusters[0].cluster.certificate-authority-data)
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.kube_config.host
+    client_certificate     = local.kube_config.client_certificate
+    client_key             = local.kube_config.client_key
+    cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.kube_config.host
+  client_certificate     = local.kube_config.client_certificate
+  client_key             = local.kube_config.client_key
+  cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+}
+
+resource "helm_release" "ingress_nginx" {
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  chart            = "ingress-nginx"
+  version          = var.chart_version
+  namespace        = "ingress-nginx"
+  create_namespace = true
+
+  # Replicas
+  set {
+    name  = "controller.replicaCount"
+    value = tostring(var.replica_count)
+  }
+
+  # Azure LoadBalancer
+  set {
+    name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-health-probe-request-path"
+    value = "/healthz"
+  }
+
+  # Resources
+  set {
+    name  = "controller.resources.requests.cpu"
+    value = "100m"
+  }
+
+  set {
+    name  = "controller.resources.requests.memory"
+    value = "128Mi"
+  }
+
+  set {
+    name  = "controller.resources.limits.cpu"
+    value = "500m"
+  }
+
+  set {
+    name  = "controller.resources.limits.memory"
+    value = "256Mi"
+  }
+
+  # Prometheus metrics
+  set {
+    name  = "controller.metrics.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "controller.metrics.serviceMonitor.enabled"
+    value = "true"
+  }
+
+  # Pod disruption budget
+  set {
+    name  = "controller.minAvailable"
+    value = "1"
+  }
+
+  # Use IngressClass
+  set {
+    name  = "controller.ingressClassResource.name"
+    value = "nginx"
+  }
+
+  set {
+    name  = "controller.ingressClassResource.default"
+    value = "true"
+  }
+
+  timeout = 600
+}

--- a/infra/terraform/modules/ingress-nginx/outputs.tf
+++ b/infra/terraform/modules/ingress-nginx/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  description = "Namespace where ingress-nginx is deployed"
+  value       = helm_release.ingress_nginx.namespace
+}
+
+output "ingress_class" {
+  description = "IngressClass name"
+  value       = "nginx"
+}

--- a/infra/terraform/modules/ingress-nginx/variables.tf
+++ b/infra/terraform/modules/ingress-nginx/variables.tf
@@ -1,0 +1,39 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "project" {
+  description = "Project prefix for resource naming"
+  type        = string
+  default     = "sb"
+}
+
+variable "kube_config_raw" {
+  description = "Raw kubeconfig for the AKS cluster"
+  type        = string
+  sensitive   = true
+}
+
+variable "chart_version" {
+  description = "ingress-nginx Helm chart version"
+  type        = string
+  default     = "4.12.0"
+}
+
+variable "replica_count" {
+  description = "Number of ingress controller replicas"
+  type        = number
+  default     = 2
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/ingress-nginx/versions.tf
+++ b/infra/terraform/modules/ingress-nginx/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.15"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.33"
+    }
+  }
+}

--- a/infra/terraform/modules/kube-prometheus-stack/main.tf
+++ b/infra/terraform/modules/kube-prometheus-stack/main.tf
@@ -1,0 +1,195 @@
+# Deploy kube-prometheus-stack: Prometheus Operator, Prometheus, Grafana, AlertManager.
+
+locals {
+  parsed_kubeconfig = yamldecode(var.kube_config_raw)
+
+  kube_config = {
+    host                   = local.parsed_kubeconfig.clusters[0].cluster.server
+    client_certificate     = base64decode(local.parsed_kubeconfig.users[0].user.client-certificate-data)
+    client_key             = base64decode(local.parsed_kubeconfig.users[0].user.client-key-data)
+    cluster_ca_certificate = base64decode(local.parsed_kubeconfig.clusters[0].cluster.certificate-authority-data)
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.kube_config.host
+    client_certificate     = local.kube_config.client_certificate
+    client_key             = local.kube_config.client_key
+    cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.kube_config.host
+  client_certificate     = local.kube_config.client_certificate
+  client_key             = local.kube_config.client_key
+  cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+}
+
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = var.namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "signalbeam.io/environment"    = var.environment
+      "signalbeam.io/project"        = var.project
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [metadata[0].labels, metadata[0].annotations]
+  }
+}
+
+resource "helm_release" "kube_prometheus_stack" {
+  name       = "kube-prometheus-stack"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-prometheus-stack"
+  version    = var.chart_version
+  namespace  = kubernetes_namespace.monitoring.metadata[0].name
+
+  # Prometheus
+  set {
+    name  = "prometheus.prometheusSpec.retention"
+    value = var.prometheus_retention
+  }
+
+  set {
+    name  = "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage"
+    value = var.prometheus_storage_size
+  }
+
+  set {
+    name  = "prometheus.prometheusSpec.resources.requests.cpu"
+    value = "200m"
+  }
+
+  set {
+    name  = "prometheus.prometheusSpec.resources.requests.memory"
+    value = "512Mi"
+  }
+
+  set {
+    name  = "prometheus.prometheusSpec.resources.limits.cpu"
+    value = "1"
+  }
+
+  set {
+    name  = "prometheus.prometheusSpec.resources.limits.memory"
+    value = "1Gi"
+  }
+
+  # Scrape ServiceMonitors from all namespaces
+  set {
+    name  = "prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues"
+    value = "false"
+  }
+
+  set {
+    name  = "prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues"
+    value = "false"
+  }
+
+  # Grafana
+  set {
+    name  = "grafana.adminPassword"
+    value = var.grafana_admin_password
+  }
+
+  set {
+    name  = "grafana.persistence.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "grafana.persistence.size"
+    value = var.grafana_storage_size
+  }
+
+  set {
+    name  = "grafana.resources.requests.cpu"
+    value = "100m"
+  }
+
+  set {
+    name  = "grafana.resources.requests.memory"
+    value = "256Mi"
+  }
+
+  set {
+    name  = "grafana.resources.limits.cpu"
+    value = "500m"
+  }
+
+  set {
+    name  = "grafana.resources.limits.memory"
+    value = "512Mi"
+  }
+
+  # Add Loki and Tempo as Grafana datasources
+  set {
+    name  = "grafana.additionalDataSources[0].name"
+    value = "Loki"
+  }
+
+  set {
+    name  = "grafana.additionalDataSources[0].type"
+    value = "loki"
+  }
+
+  set {
+    name  = "grafana.additionalDataSources[0].url"
+    value = "http://loki.${var.namespace}:3100"
+  }
+
+  set {
+    name  = "grafana.additionalDataSources[0].access"
+    value = "proxy"
+  }
+
+  set {
+    name  = "grafana.additionalDataSources[1].name"
+    value = "Tempo"
+  }
+
+  set {
+    name  = "grafana.additionalDataSources[1].type"
+    value = "tempo"
+  }
+
+  set {
+    name  = "grafana.additionalDataSources[1].url"
+    value = "http://tempo.${var.namespace}:3100"
+  }
+
+  set {
+    name  = "grafana.additionalDataSources[1].access"
+    value = "proxy"
+  }
+
+  # AlertManager — minimal config for dev
+  set {
+    name  = "alertmanager.alertmanagerSpec.resources.requests.cpu"
+    value = "50m"
+  }
+
+  set {
+    name  = "alertmanager.alertmanagerSpec.resources.requests.memory"
+    value = "64Mi"
+  }
+
+  set {
+    name  = "alertmanager.alertmanagerSpec.resources.limits.cpu"
+    value = "100m"
+  }
+
+  set {
+    name  = "alertmanager.alertmanagerSpec.resources.limits.memory"
+    value = "128Mi"
+  }
+
+  timeout = 900
+
+  depends_on = [kubernetes_namespace.monitoring]
+}

--- a/infra/terraform/modules/kube-prometheus-stack/outputs.tf
+++ b/infra/terraform/modules/kube-prometheus-stack/outputs.tf
@@ -1,0 +1,14 @@
+output "namespace" {
+  description = "Namespace where the monitoring stack is deployed"
+  value       = helm_release.kube_prometheus_stack.namespace
+}
+
+output "prometheus_url" {
+  description = "Prometheus internal URL"
+  value       = "http://kube-prometheus-stack-prometheus.${helm_release.kube_prometheus_stack.namespace}:9090"
+}
+
+output "grafana_url" {
+  description = "Grafana internal URL"
+  value       = "http://kube-prometheus-stack-grafana.${helm_release.kube_prometheus_stack.namespace}"
+}

--- a/infra/terraform/modules/kube-prometheus-stack/variables.tf
+++ b/infra/terraform/modules/kube-prometheus-stack/variables.tf
@@ -1,0 +1,64 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "project" {
+  description = "Project prefix for resource naming"
+  type        = string
+  default     = "sb"
+}
+
+variable "kube_config_raw" {
+  description = "Raw kubeconfig for the AKS cluster"
+  type        = string
+  sensitive   = true
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for the monitoring stack"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "chart_version" {
+  description = "kube-prometheus-stack Helm chart version"
+  type        = string
+  default     = "67.9.0"
+}
+
+variable "grafana_admin_password" {
+  description = "Grafana admin password"
+  type        = string
+  sensitive   = true
+  default     = "signalbeam-admin"
+}
+
+variable "prometheus_retention" {
+  description = "Prometheus data retention period"
+  type        = string
+  default     = "15d"
+}
+
+variable "prometheus_storage_size" {
+  description = "Prometheus persistent volume size"
+  type        = string
+  default     = "20Gi"
+}
+
+variable "grafana_storage_size" {
+  description = "Grafana persistent volume size"
+  type        = string
+  default     = "5Gi"
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/kube-prometheus-stack/versions.tf
+++ b/infra/terraform/modules/kube-prometheus-stack/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.15"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.33"
+    }
+  }
+}

--- a/infra/terraform/modules/loki/main.tf
+++ b/infra/terraform/modules/loki/main.tf
@@ -1,0 +1,161 @@
+# Deploy Grafana Loki for log aggregation in single-binary mode (dev/small clusters).
+
+locals {
+  parsed_kubeconfig = yamldecode(var.kube_config_raw)
+
+  kube_config = {
+    host                   = local.parsed_kubeconfig.clusters[0].cluster.server
+    client_certificate     = base64decode(local.parsed_kubeconfig.users[0].user.client-certificate-data)
+    client_key             = base64decode(local.parsed_kubeconfig.users[0].user.client-key-data)
+    cluster_ca_certificate = base64decode(local.parsed_kubeconfig.clusters[0].cluster.certificate-authority-data)
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.kube_config.host
+    client_certificate     = local.kube_config.client_certificate
+    client_key             = local.kube_config.client_key
+    cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.kube_config.host
+  client_certificate     = local.kube_config.client_certificate
+  client_key             = local.kube_config.client_key
+  cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+}
+
+resource "helm_release" "loki" {
+  name       = "loki"
+  repository = "https://grafana.github.io/helm-charts"
+  chart      = "loki"
+  version    = var.chart_version
+  namespace  = var.namespace
+
+  # Single-binary mode for dev/small clusters
+  set {
+    name  = "deploymentMode"
+    value = "SingleBinary"
+  }
+
+  set {
+    name  = "singleBinary.replicas"
+    value = "1"
+  }
+
+  # Disable distributed components
+  set {
+    name  = "read.replicas"
+    value = "0"
+  }
+
+  set {
+    name  = "write.replicas"
+    value = "0"
+  }
+
+  set {
+    name  = "backend.replicas"
+    value = "0"
+  }
+
+  # Filesystem storage (no object store for dev)
+  set {
+    name  = "loki.storage.type"
+    value = "filesystem"
+  }
+
+  set {
+    name  = "loki.commonConfig.replication_factor"
+    value = "1"
+  }
+
+  set {
+    name  = "loki.schemaConfig.configs[0].from"
+    value = "2024-01-01"
+  }
+
+  set {
+    name  = "loki.schemaConfig.configs[0].store"
+    value = "tsdb"
+  }
+
+  set {
+    name  = "loki.schemaConfig.configs[0].object_store"
+    value = "filesystem"
+  }
+
+  set {
+    name  = "loki.schemaConfig.configs[0].schema"
+    value = "v13"
+  }
+
+  set {
+    name  = "loki.schemaConfig.configs[0].index.prefix"
+    value = "loki_index_"
+  }
+
+  set {
+    name  = "loki.schemaConfig.configs[0].index.period"
+    value = "24h"
+  }
+
+  # Retention
+  set {
+    name  = "loki.limits_config.retention_period"
+    value = var.retention_period
+  }
+
+  # Resources
+  set {
+    name  = "singleBinary.resources.requests.cpu"
+    value = "100m"
+  }
+
+  set {
+    name  = "singleBinary.resources.requests.memory"
+    value = "256Mi"
+  }
+
+  set {
+    name  = "singleBinary.resources.limits.cpu"
+    value = "500m"
+  }
+
+  set {
+    name  = "singleBinary.resources.limits.memory"
+    value = "512Mi"
+  }
+
+  # Persistence
+  set {
+    name  = "singleBinary.persistence.size"
+    value = var.storage_size
+  }
+
+  # Disable gateway for internal-only access
+  set {
+    name  = "gateway.enabled"
+    value = "false"
+  }
+
+  # Disable self-monitoring to reduce overhead
+  set {
+    name  = "monitoring.selfMonitoring.enabled"
+    value = "false"
+  }
+
+  set {
+    name  = "monitoring.lokiCanary.enabled"
+    value = "false"
+  }
+
+  set {
+    name  = "test.enabled"
+    value = "false"
+  }
+
+  timeout = 600
+}

--- a/infra/terraform/modules/loki/outputs.tf
+++ b/infra/terraform/modules/loki/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  description = "Namespace where Loki is deployed"
+  value       = helm_release.loki.namespace
+}
+
+output "url" {
+  description = "Loki internal push URL"
+  value       = "http://loki.${helm_release.loki.namespace}:3100"
+}

--- a/infra/terraform/modules/loki/variables.tf
+++ b/infra/terraform/modules/loki/variables.tf
@@ -1,0 +1,51 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "project" {
+  description = "Project prefix for resource naming"
+  type        = string
+  default     = "sb"
+}
+
+variable "kube_config_raw" {
+  description = "Raw kubeconfig for the AKS cluster"
+  type        = string
+  sensitive   = true
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for Loki"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "chart_version" {
+  description = "Loki Helm chart version"
+  type        = string
+  default     = "6.24.0"
+}
+
+variable "storage_size" {
+  description = "Loki persistent volume size"
+  type        = string
+  default     = "10Gi"
+}
+
+variable "retention_period" {
+  description = "Log retention period"
+  type        = string
+  default     = "168h"
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/loki/versions.tf
+++ b/infra/terraform/modules/loki/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.15"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.33"
+    }
+  }
+}

--- a/infra/terraform/modules/otel-collector/main.tf
+++ b/infra/terraform/modules/otel-collector/main.tf
@@ -1,0 +1,167 @@
+# Deploy OpenTelemetry Collector to route traces, metrics, and logs
+# from microservices to Tempo, Prometheus, and Loki.
+
+locals {
+  parsed_kubeconfig = yamldecode(var.kube_config_raw)
+
+  kube_config = {
+    host                   = local.parsed_kubeconfig.clusters[0].cluster.server
+    client_certificate     = base64decode(local.parsed_kubeconfig.users[0].user.client-certificate-data)
+    client_key             = base64decode(local.parsed_kubeconfig.users[0].user.client-key-data)
+    cluster_ca_certificate = base64decode(local.parsed_kubeconfig.clusters[0].cluster.certificate-authority-data)
+  }
+
+  common_labels = {
+    "app.kubernetes.io/managed-by" = "terraform"
+    "signalbeam.io/environment"    = var.environment
+    "signalbeam.io/project"        = var.project
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.kube_config.host
+    client_certificate     = local.kube_config.client_certificate
+    client_key             = local.kube_config.client_key
+    cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.kube_config.host
+  client_certificate     = local.kube_config.client_certificate
+  client_key             = local.kube_config.client_key
+  cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+}
+
+resource "helm_release" "otel_collector" {
+  name       = "otel-collector"
+  repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
+  chart      = "opentelemetry-collector"
+  version    = var.chart_version
+  namespace  = var.namespace
+
+  # Deploy as Deployment (not DaemonSet) for app-level telemetry
+  set {
+    name  = "mode"
+    value = "deployment"
+  }
+
+  set {
+    name  = "replicaCount"
+    value = "2"
+  }
+
+  # Resources
+  set {
+    name  = "resources.requests.cpu"
+    value = "100m"
+  }
+
+  set {
+    name  = "resources.requests.memory"
+    value = "256Mi"
+  }
+
+  set {
+    name  = "resources.limits.cpu"
+    value = "500m"
+  }
+
+  set {
+    name  = "resources.limits.memory"
+    value = "512Mi"
+  }
+
+  # OTLP receiver ports
+  set {
+    name  = "ports.otlp.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "ports.otlp-http.enabled"
+    value = "true"
+  }
+
+  # Prometheus metrics port for self-monitoring
+  set {
+    name  = "ports.prometheus.enabled"
+    value = "true"
+  }
+
+  # Collector pipeline configuration
+  values = [yamlencode({
+    config = {
+      receivers = {
+        otlp = {
+          protocols = {
+            grpc = { endpoint = "0.0.0.0:4317" }
+            http = { endpoint = "0.0.0.0:4318" }
+          }
+        }
+      }
+
+      processors = {
+        batch = {
+          timeout         = "5s"
+          send_batch_size = 1024
+        }
+        memory_limiter = {
+          check_interval         = "1s"
+          limit_mib              = 400
+          spike_limit_percentage = 30
+        }
+      }
+
+      exporters = {
+        # Traces → Tempo
+        otlp = {
+          endpoint = "tempo.${var.monitoring_namespace}:4317"
+          tls      = { insecure = true }
+        }
+
+        # Metrics → Prometheus (remote write)
+        prometheusremotewrite = {
+          endpoint = "http://kube-prometheus-stack-prometheus.${var.monitoring_namespace}:9090/api/v1/write"
+        }
+
+        # Logs → Loki
+        loki = {
+          endpoint = "http://loki.${var.monitoring_namespace}:3100/loki/api/v1/push"
+        }
+
+        # Debug logging (minimal)
+        debug = {
+          verbosity = "basic"
+        }
+      }
+
+      service = {
+        pipelines = {
+          traces = {
+            receivers  = ["otlp"]
+            processors = ["memory_limiter", "batch"]
+            exporters  = ["otlp"]
+          }
+          metrics = {
+            receivers  = ["otlp"]
+            processors = ["memory_limiter", "batch"]
+            exporters  = ["prometheusremotewrite"]
+          }
+          logs = {
+            receivers  = ["otlp"]
+            processors = ["memory_limiter", "batch"]
+            exporters  = ["loki"]
+          }
+        }
+
+        telemetry = {
+          metrics = { address = "0.0.0.0:8888" }
+        }
+      }
+    }
+  })]
+
+  timeout = 600
+}

--- a/infra/terraform/modules/otel-collector/outputs.tf
+++ b/infra/terraform/modules/otel-collector/outputs.tf
@@ -1,0 +1,14 @@
+output "namespace" {
+  description = "Namespace where the OTEL Collector is deployed"
+  value       = helm_release.otel_collector.namespace
+}
+
+output "otlp_grpc_endpoint" {
+  description = "OTEL Collector OTLP gRPC endpoint"
+  value       = "http://otel-collector.${helm_release.otel_collector.namespace}:4317"
+}
+
+output "otlp_http_endpoint" {
+  description = "OTEL Collector OTLP HTTP endpoint"
+  value       = "http://otel-collector.${helm_release.otel_collector.namespace}:4318"
+}

--- a/infra/terraform/modules/otel-collector/variables.tf
+++ b/infra/terraform/modules/otel-collector/variables.tf
@@ -1,0 +1,45 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "project" {
+  description = "Project prefix for resource naming"
+  type        = string
+  default     = "sb"
+}
+
+variable "kube_config_raw" {
+  description = "Raw kubeconfig for the AKS cluster"
+  type        = string
+  sensitive   = true
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for the OTEL Collector"
+  type        = string
+  default     = "signalbeam"
+}
+
+variable "chart_version" {
+  description = "OpenTelemetry Collector Helm chart version"
+  type        = string
+  default     = "0.108.0"
+}
+
+variable "monitoring_namespace" {
+  description = "Namespace where Prometheus, Loki, and Tempo are deployed"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/otel-collector/versions.tf
+++ b/infra/terraform/modules/otel-collector/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.15"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.33"
+    }
+  }
+}

--- a/infra/terraform/modules/tempo/main.tf
+++ b/infra/terraform/modules/tempo/main.tf
@@ -1,0 +1,88 @@
+# Deploy Grafana Tempo for distributed tracing.
+
+locals {
+  parsed_kubeconfig = yamldecode(var.kube_config_raw)
+
+  kube_config = {
+    host                   = local.parsed_kubeconfig.clusters[0].cluster.server
+    client_certificate     = base64decode(local.parsed_kubeconfig.users[0].user.client-certificate-data)
+    client_key             = base64decode(local.parsed_kubeconfig.users[0].user.client-key-data)
+    cluster_ca_certificate = base64decode(local.parsed_kubeconfig.clusters[0].cluster.certificate-authority-data)
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.kube_config.host
+    client_certificate     = local.kube_config.client_certificate
+    client_key             = local.kube_config.client_key
+    cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.kube_config.host
+  client_certificate     = local.kube_config.client_certificate
+  client_key             = local.kube_config.client_key
+  cluster_ca_certificate = local.kube_config.cluster_ca_certificate
+}
+
+resource "helm_release" "tempo" {
+  name       = "tempo"
+  repository = "https://grafana.github.io/helm-charts"
+  chart      = "tempo"
+  version    = var.chart_version
+  namespace  = var.namespace
+
+  # OTLP gRPC receiver (used by OTEL Collector)
+  set {
+    name  = "tempo.receivers.otlp.protocols.grpc.endpoint"
+    value = "0.0.0.0:4317"
+  }
+
+  # OTLP HTTP receiver
+  set {
+    name  = "tempo.receivers.otlp.protocols.http.endpoint"
+    value = "0.0.0.0:4318"
+  }
+
+  # Retention
+  set {
+    name  = "tempo.retention"
+    value = var.retention_period
+  }
+
+  # Local storage for dev
+  set {
+    name  = "persistence.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "persistence.size"
+    value = var.storage_size
+  }
+
+  # Resources
+  set {
+    name  = "tempo.resources.requests.cpu"
+    value = "100m"
+  }
+
+  set {
+    name  = "tempo.resources.requests.memory"
+    value = "256Mi"
+  }
+
+  set {
+    name  = "tempo.resources.limits.cpu"
+    value = "500m"
+  }
+
+  set {
+    name  = "tempo.resources.limits.memory"
+    value = "512Mi"
+  }
+
+  timeout = 600
+}

--- a/infra/terraform/modules/tempo/outputs.tf
+++ b/infra/terraform/modules/tempo/outputs.tf
@@ -1,0 +1,14 @@
+output "namespace" {
+  description = "Namespace where Tempo is deployed"
+  value       = helm_release.tempo.namespace
+}
+
+output "otlp_grpc_url" {
+  description = "Tempo OTLP gRPC endpoint for trace ingestion"
+  value       = "tempo.${helm_release.tempo.namespace}:4317"
+}
+
+output "query_url" {
+  description = "Tempo query URL (Grafana datasource)"
+  value       = "http://tempo.${helm_release.tempo.namespace}:3100"
+}

--- a/infra/terraform/modules/tempo/variables.tf
+++ b/infra/terraform/modules/tempo/variables.tf
@@ -1,0 +1,51 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "project" {
+  description = "Project prefix for resource naming"
+  type        = string
+  default     = "sb"
+}
+
+variable "kube_config_raw" {
+  description = "Raw kubeconfig for the AKS cluster"
+  type        = string
+  sensitive   = true
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for Tempo"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "chart_version" {
+  description = "Tempo Helm chart version"
+  type        = string
+  default     = "1.14.0"
+}
+
+variable "storage_size" {
+  description = "Tempo persistent volume size"
+  type        = string
+  default     = "10Gi"
+}
+
+variable "retention_period" {
+  description = "Trace retention period"
+  type        = string
+  default     = "168h"
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/tempo/versions.tf
+++ b/infra/terraform/modules/tempo/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.15"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.33"
+    }
+  }
+}

--- a/infra/terragrunt/dev/cert-manager/terragrunt.hcl
+++ b/infra/terragrunt/dev/cert-manager/terragrunt.hcl
@@ -1,0 +1,51 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../terraform/modules/cert-manager"
+}
+
+dependency "aks_cluster" {
+  config_path = "../aks-cluster"
+
+  mock_outputs = {
+    name            = "mock-aks"
+    kube_config_raw = "mock-kubeconfig"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "managed_identity" {
+  config_path = "../managed-identity"
+
+  mock_outputs = {
+    client_id = "00000000-0000-0000-0000-000000000000"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "dns" {
+  config_path = "../dns"
+
+  mock_outputs = {
+    name = "dev.signalbeam.io"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "resource_group" {
+  config_path = "../resource-group"
+
+  mock_outputs = {
+    name = "mock-rg"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+inputs = {
+  kube_config_raw             = dependency.aks_cluster.outputs.kube_config_raw
+  workload_identity_client_id = dependency.managed_identity.outputs.client_id
+  dns_zone_name               = dependency.dns.outputs.name
+  dns_zone_resource_group     = dependency.resource_group.outputs.name
+}

--- a/infra/terragrunt/dev/ingress-nginx/terragrunt.hcl
+++ b/infra/terragrunt/dev/ingress-nginx/terragrunt.hcl
@@ -1,0 +1,21 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../terraform/modules/ingress-nginx"
+}
+
+dependency "aks_cluster" {
+  config_path = "../aks-cluster"
+
+  mock_outputs = {
+    name            = "mock-aks"
+    kube_config_raw = "mock-kubeconfig"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+inputs = {
+  kube_config_raw = dependency.aks_cluster.outputs.kube_config_raw
+}

--- a/infra/terragrunt/dev/kube-prometheus-stack/terragrunt.hcl
+++ b/infra/terragrunt/dev/kube-prometheus-stack/terragrunt.hcl
@@ -1,0 +1,21 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../terraform/modules/kube-prometheus-stack"
+}
+
+dependency "aks_cluster" {
+  config_path = "../aks-cluster"
+
+  mock_outputs = {
+    name            = "mock-aks"
+    kube_config_raw = "mock-kubeconfig"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+inputs = {
+  kube_config_raw = dependency.aks_cluster.outputs.kube_config_raw
+}

--- a/infra/terragrunt/dev/loki/terragrunt.hcl
+++ b/infra/terragrunt/dev/loki/terragrunt.hcl
@@ -1,0 +1,31 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../terraform/modules/loki"
+}
+
+dependency "aks_cluster" {
+  config_path = "../aks-cluster"
+
+  mock_outputs = {
+    name            = "mock-aks"
+    kube_config_raw = "mock-kubeconfig"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "kube_prometheus_stack" {
+  config_path = "../kube-prometheus-stack"
+
+  mock_outputs = {
+    namespace = "monitoring"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+inputs = {
+  kube_config_raw = dependency.aks_cluster.outputs.kube_config_raw
+  namespace       = dependency.kube_prometheus_stack.outputs.namespace
+}

--- a/infra/terragrunt/dev/otel-collector/terragrunt.hcl
+++ b/infra/terragrunt/dev/otel-collector/terragrunt.hcl
@@ -1,0 +1,51 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../terraform/modules/otel-collector"
+}
+
+dependency "aks_cluster" {
+  config_path = "../aks-cluster"
+
+  mock_outputs = {
+    name            = "mock-aks"
+    kube_config_raw = "mock-kubeconfig"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "kube_prometheus_stack" {
+  config_path = "../kube-prometheus-stack"
+
+  mock_outputs = {
+    namespace = "monitoring"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "loki" {
+  config_path = "../loki"
+
+  mock_outputs = {
+    namespace = "monitoring"
+    url       = "http://loki.monitoring:3100"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "tempo" {
+  config_path = "../tempo"
+
+  mock_outputs = {
+    namespace     = "monitoring"
+    otlp_grpc_url = "tempo.monitoring:4317"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+inputs = {
+  kube_config_raw      = dependency.aks_cluster.outputs.kube_config_raw
+  monitoring_namespace = dependency.kube_prometheus_stack.outputs.namespace
+}

--- a/infra/terragrunt/dev/tempo/terragrunt.hcl
+++ b/infra/terragrunt/dev/tempo/terragrunt.hcl
@@ -1,0 +1,31 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../terraform/modules/tempo"
+}
+
+dependency "aks_cluster" {
+  config_path = "../aks-cluster"
+
+  mock_outputs = {
+    name            = "mock-aks"
+    kube_config_raw = "mock-kubeconfig"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "kube_prometheus_stack" {
+  config_path = "../kube-prometheus-stack"
+
+  mock_outputs = {
+    namespace = "monitoring"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+inputs = {
+  kube_config_raw = dependency.aks_cluster.outputs.kube_config_raw
+  namespace       = dependency.kube_prometheus_stack.outputs.namespace
+}


### PR DESCRIPTION
## Summary

- Add 6 Terraform modules deploying cluster infrastructure services to AKS via Helm:
  - **cert-manager** — TLS certificate management with Let's Encrypt ClusterIssuers (prod + staging), DNS01 validation via Azure workload identity
  - **ingress-nginx** — NGINX Ingress Controller with Azure LoadBalancer (2 replicas, default IngressClass)
  - **kube-prometheus-stack** — Prometheus Operator + Prometheus (20Gi) + Grafana (5Gi, pre-configured Loki/Tempo datasources) + AlertManager
  - **loki** — Log aggregation in single-binary mode (10Gi, 7d retention)
  - **tempo** — Distributed tracing backend (10Gi, 7d retention)
  - **otel-collector** — Routes OTLP traces/metrics/logs from microservices to Tempo, Prometheus, and Loki (2 replicas)
- Wire all modules via Terragrunt with dependency ordering (Phases 6-8)
- Update infra README with architecture docs, observability pipeline, and verification commands

Relates to #166

## Test plan

- [ ] `terraform fmt -check -recursive infra/terraform/modules` passes
- [ ] `terraform validate` passes for all 6 new modules
- [ ] Terragrunt dependency graph resolves correctly (`terragrunt graph-dependencies`)
- [ ] After apply: cert-manager pods running, ClusterIssuers created
- [ ] After apply: ingress-nginx controller running with external IP
- [ ] After apply: Prometheus, Grafana, AlertManager pods running in `monitoring` namespace
- [ ] After apply: Loki and Tempo pods running in `monitoring` namespace
- [ ] After apply: OTEL Collector pods running in `signalbeam` namespace
- [ ] Microservice ServiceMonitors discovered by Prometheus
- [ ] Grafana datasources (Prometheus, Loki, Tempo) accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)