### PR TITLE
add claude code hooks, security rule, git conventions, and docs skill

### DIFF
--- a/.claude/hooks/format-on-save.sh
+++ b/.claude/hooks/format-on-save.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post-edit hook: auto-format the file that was just edited/written
+# Runs after Edit or Write tool completes
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.file_path // ""')
+
+if [[ -z "$FILE_PATH" || ! -f "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+
+case "$FILE_PATH" in
+  *.cs)
+    # Format single C# file via dotnet format
+    dotnet format "$PROJECT_DIR/src/SignalBeam.sln" --include "$FILE_PATH" --verbosity quiet 2>/dev/null || true
+    ;;
+  *.ts|*.tsx)
+    # Format single TS/TSX file via ESLint fix
+    (cd "$PROJECT_DIR/web" && npx eslint --fix "$FILE_PATH" 2>/dev/null) || true
+    ;;
+  *.tf)
+    # Format single Terraform file
+    terraform fmt "$FILE_PATH" 2>/dev/null || true
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/pre-commit-lint.sh
+++ b/.claude/hooks/pre-commit-lint.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-commit hook: lint and format changed files
+# Called by Claude Code PreToolUse hook on git commit
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only intercept git commit commands
+if [[ "$COMMAND" != *"git commit"* ]]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+ERRORS=()
+
+# Get staged files
+STAGED_CS=$(git -C "$PROJECT_DIR" diff --cached --name-only --diff-filter=ACM -- '*.cs' 2>/dev/null || true)
+STAGED_TS=$(git -C "$PROJECT_DIR" diff --cached --name-only --diff-filter=ACM -- '*.ts' '*.tsx' 2>/dev/null || true)
+STAGED_TF=$(git -C "$PROJECT_DIR" diff --cached --name-only --diff-filter=ACM -- '*.tf' 2>/dev/null || true)
+STAGED_HELM=$(git -C "$PROJECT_DIR" diff --cached --name-only --diff-filter=ACM -- 'deploy/charts/*' 2>/dev/null || true)
+
+# 1. dotnet format on staged C# files
+if [[ -n "$STAGED_CS" ]]; then
+  if ! dotnet format "$PROJECT_DIR/src/SignalBeam.sln" --verify-no-changes --verbosity quiet 2>/dev/null; then
+    # Auto-fix
+    dotnet format "$PROJECT_DIR/src/SignalBeam.sln" --verbosity quiet 2>/dev/null || true
+    # Re-stage fixed files
+    echo "$STAGED_CS" | while IFS= read -r f; do
+      [[ -f "$PROJECT_DIR/$f" ]] && git -C "$PROJECT_DIR" add "$f"
+    done
+    ERRORS+=("dotnet format: auto-fixed C# formatting issues and re-staged files")
+  fi
+fi
+
+# 2. ESLint on staged TS/TSX files
+if [[ -n "$STAGED_TS" ]]; then
+  if ! (cd "$PROJECT_DIR/web" && npx eslint --quiet $STAGED_TS 2>/dev/null); then
+    # Auto-fix
+    (cd "$PROJECT_DIR/web" && npx eslint --fix $STAGED_TS 2>/dev/null) || true
+    echo "$STAGED_TS" | while IFS= read -r f; do
+      [[ -f "$PROJECT_DIR/$f" ]] && git -C "$PROJECT_DIR" add "$f"
+    done
+    ERRORS+=("eslint: auto-fixed TypeScript lint issues and re-staged files")
+  fi
+fi
+
+# 3. terraform fmt on staged .tf files
+if [[ -n "$STAGED_TF" ]]; then
+  if ! terraform fmt -check -recursive "$PROJECT_DIR/infra/" >/dev/null 2>&1; then
+    terraform fmt -recursive "$PROJECT_DIR/infra/" >/dev/null 2>&1 || true
+    echo "$STAGED_TF" | while IFS= read -r f; do
+      [[ -f "$PROJECT_DIR/$f" ]] && git -C "$PROJECT_DIR" add "$f"
+    done
+    ERRORS+=("terraform fmt: auto-fixed Terraform formatting and re-staged files")
+  fi
+fi
+
+# 4. helm lint on staged chart changes
+if [[ -n "$STAGED_HELM" ]]; then
+  CHART_DIRS=$(echo "$STAGED_HELM" | grep -oP 'deploy/charts/[^/]+' | sort -u)
+  for chart_dir in $CHART_DIRS; do
+    if [[ -f "$PROJECT_DIR/$chart_dir/Chart.yaml" ]]; then
+      if ! helm lint "$PROJECT_DIR/$chart_dir" --quiet 2>/dev/null; then
+        ERRORS+=("helm lint: $chart_dir has lint errors (cannot auto-fix)")
+      fi
+    fi
+  done
+fi
+
+# Report results
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  # Join errors
+  MSG=$(printf '%s\n' "${ERRORS[@]}")
+
+  # Check if any are non-auto-fixable
+  if echo "$MSG" | grep -q "cannot auto-fix"; then
+    echo "$MSG" >&2
+    exit 2  # Block commit
+  fi
+
+  # All were auto-fixed — allow commit to proceed
+  echo "$MSG" >&2
+  exit 0
+fi
+
+exit 0

--- a/.claude/rules/git-conventions.md
+++ b/.claude/rules/git-conventions.md
@@ -1,0 +1,69 @@
+---
+paths:
+  - "**"
+---
+
+# Git Conventions
+
+## Branch Naming
+
+Format: `{username}/{issue-number}-{short-slug}`
+
+Examples:
+- `makigjuro/166-aks-cluster-services`
+- `makigjuro/247-real-time-foundation-sse-cdc-websocket`
+
+Legacy branches used `feature/` prefix — new branches must use the `{username}/` format.
+
+## Commit Messages
+
+Format: lowercase imperative, no period at end
+
+```
+{verb} {what was done}
+```
+
+**Verbs:**
+- `add` — new feature or file (not "added", not "adds")
+- `fix` — bug fix
+- `update` — enhancement to existing feature
+- `remove` — delete code or feature
+- `refactor` — restructure without behaviour change
+- `rename` — rename files, variables, or types
+- `move` — relocate files between directories
+- `enforce` — add or tighten a rule/constraint
+- `address` — respond to review feedback
+
+**Examples from this repo:**
+```
+add DeviceManager Helm chart with environment-specific values
+fix: address review feedback on SSE connection manager and endpoint
+deploy NATS with JetStream to AKS via Terraform + Helm
+address review findings: resource limits, labels, kubeconfig parsing
+enforce mandatory EF Core migrations in rules, skills, and workflow
+```
+
+**Rules:**
+- First line under 72 characters
+- No capitalization of first word (lowercase)
+- No trailing period
+- One logical change per commit — not one giant commit per feature
+- Reference issue number in the PR, not in every commit message
+
+## Protected Branches
+
+- Never commit directly to `main` — always use feature branches
+- Never force-push to `main`
+- Merge via pull request only
+
+## Staging
+
+- Stage specific files by name, not `git add -A` or `git add .`
+- Never commit `.env`, `appsettings.*.json` with secrets, or `**/bin/` / `**/obj/` directories
+- Review `git diff --cached` before committing
+
+## PR Conventions
+
+- PR title: imperative mood, under 70 characters (matches the primary commit)
+- Link to GitHub issue with `Closes #{number}`
+- One PR per issue — don't bundle unrelated changes

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,59 @@
+---
+paths:
+  - "src/**/*.cs"
+  - "web/src/**/*.ts"
+  - "web/src/**/*.tsx"
+---
+
+# Security Rules
+
+Apply these rules while writing code, not just during review.
+
+## Injection Prevention
+
+- **SQL:** Never concatenate user input into queries. Use parameterized queries only.
+  - Forbidden: `FromSqlRaw($"SELECT ... WHERE id = '{id}'")`, string interpolation in SQL
+  - Required: `FromSqlInterpolated`, `FromSqlRaw` with parameters, or LINQ/EF Core queries
+- **Command:** Never pass unsanitized input to `Process.Start`, `ProcessStartInfo`, or shell commands
+- **NATS subjects:** Never interpolate user input into subject strings without validation
+
+## Secrets & Credentials
+
+- Never hardcode secrets, API keys, connection strings, or tokens in source code
+- Use configuration (`IConfiguration`, `IOptions<T>`) or environment variables
+- Never log secrets, tokens, passwords, or PII — use structured logging with explicit fields
+- Connection strings go in `appsettings.json` (dev) or Kubernetes Secrets (deployed)
+- Check: no `password=`, `apikey=`, `secret=`, `bearer` literals in committed code
+
+## Authentication & Authorization
+
+- Every endpoint must require authentication unless explicitly public
+- Validate `TenantId` on every request — never trust client-provided tenant without verification
+- API key validation must be constant-time to prevent timing attacks
+- JWT tokens: validate issuer, audience, and expiry — never skip validation
+
+## Input Validation
+
+- Validate all external input at the API boundary (endpoint or command level)
+- Use FluentValidation for command/request validation
+- Enforce maximum lengths on all string inputs to prevent resource exhaustion
+- Validate GUIDs, enums, and numeric ranges before passing to domain logic
+
+## Frontend (React/TypeScript)
+
+- Never use `dangerouslySetInnerHTML` without DOMPurify sanitization
+- Never store tokens in `localStorage` for production — use `httpOnly` cookies or secure session storage
+- Sanitize any user-provided content before rendering
+- CORS: only allow specific origins, never `*` in production configuration
+
+## Error Responses
+
+- Never expose stack traces, internal paths, or implementation details in API error responses
+- Use the Result pattern error shape: `{ error: "CODE", message: "user-safe message", type: "ErrorType" }`
+- Log the full exception server-side, return only the error code to the client
+
+## Dependencies
+
+- Never add packages without checking for known vulnerabilities
+- Pin package versions via `Directory.Packages.props` (backend) and `package-lock.json` (frontend)
+- Prefer well-maintained packages with active security response

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -5,10 +5,10 @@ Follow this end-to-end process when building features. Each step has a correspon
 ## Workflow Overview
 
 ```
-PRD → Issues → Branch → Implement → Verify → Review → PR
- │       │        │          │          │        │      │
-/prd  /create   /start    /add-*    /check   /code   /complete
-      -tasks    -work               -arch   -review  -task
+PRD → Issues → Branch → Implement → Verify → Review → Docs → PR
+ │       │        │          │          │        │       │      │
+/prd  /create   /start    /add-*    /check   /code   /docs  /complete
+      -tasks    -work               -arch   -review         -task
                                     /lint
                                     /run-tests
 ```
@@ -123,7 +123,30 @@ Plan → Issues → Branch → Implement → Verify → PR
 - **Standard workflow:** Changes touch application code (`src/`, `web/`, `tests/`)
 - **Both:** If a feature needs app code + infra changes, use standard workflow with `/infra-lint` for validation
 
-## 8. Diagnose (`/diagnose`)
+## 8. Document (`/docs`)
+
+Keep documentation in sync with code changes:
+
+```bash
+/docs service device-manager    # Full service doc (endpoints, events, config)
+/docs api device-manager        # API endpoint reference only
+/docs architecture              # Update technical architecture overview
+/docs domain                    # Update domain model (entities, value objects, events)
+/docs runbook device-manager    # Operational runbook (health, alerts, troubleshooting)
+/docs quickstart                # Update getting started guide
+/docs all                       # Detect stale docs and regenerate
+/docs                           # Auto-detect what needs updating
+```
+
+**When to run:**
+- After adding/modifying endpoints → `/docs api {service}`
+- After adding entities or events → `/docs domain`
+- After changing infra/deploy → `/docs architecture`
+- Before a release → `/docs all`
+
+Output paths follow `docs/services/{service-name}/`, `docs/architecture/`, or `docs/quickstart.md`. Generated sections are marked with `<!-- BEGIN GENERATED -->` / `<!-- END GENERATED -->` so manual content is preserved on regeneration.
+
+## 9. Diagnose (`/diagnose`)
 
 When something goes wrong:
 - Structured evidence gathering
@@ -153,6 +176,7 @@ When something goes wrong:
 | `/task-check` | Verify acceptance criteria |
 | `/complete-task` | Full completion workflow |
 | `/create-pr` | Create pull request |
+| `/docs` | Generate/update documentation from code |
 | `/diagnose` | Investigate problems |
 | `/infra-plan` | Plan infrastructure changes |
 | `/add-terraform-module` | Scaffold Terraform module |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,28 @@
 {
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-lint.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-on-save.sh"
+          }
+        ]
+      }
+    ]
+  },
   "subagents": {
     "reviewer": {
       "description": "Reviews code changes for security, architecture, and quality issues. Use for PR reviews and pre-merge checks.",

--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: docs
+description: Generate or update project documentation from code — API docs, service docs, architecture docs, or runbooks
+allowed-tools: Bash, Read, Glob, Grep, Write, Edit
+user-invocable: true
+---
+
+# Generate / Update Documentation
+
+Generate or update markdown documentation by analyzing the actual codebase. Never fabricate — every statement must be backed by code you've read.
+
+## Arguments
+
+- `{target}` — What to document. One of:
+  - `service {name}` — Full service documentation (endpoints, events, config)
+  - `api {service}` — API endpoint reference for a service
+  - `architecture` — Update the technical architecture doc
+  - `domain` — Update the domain model doc
+  - `runbook {service}` — Operational runbook (health checks, alerts, troubleshooting)
+  - `quickstart` — Update the quickstart / getting started guide
+  - `all` — Regenerate all outdated docs
+
+If no argument given, detect what's changed since last docs update and suggest what needs refreshing.
+
+## Process
+
+### Step 1: Detect Scope
+
+If no target specified:
+```bash
+# Find docs that may be stale — compare last doc commit vs last code commit
+git log -1 --format=%H -- docs/
+git log -1 --format=%H -- src/ web/ deploy/ infra/
+
+# Show what code changed since docs were last updated
+git diff {last-docs-commit}..HEAD --stat -- src/ web/ deploy/ infra/
+```
+
+Present the user with a summary of what's changed and recommend which docs to update.
+
+### Step 2: Gather Evidence
+
+Read the actual code — do NOT guess or use stale memory. For each doc type:
+
+**Service doc (`docs/services/{service-name}/README.md`):**
+1. Read `src/{Service}/{Service}.Host/Program.cs` — DI, middleware, config sections
+2. Read `src/{Service}/{Service}.Host/Endpoints/` — all endpoint files
+3. Read `src/{Service}/{Service}.Application/Commands/` — all command records
+4. Read `src/{Service}/{Service}.Application/Queries/` — all query records
+5. Read `src/{Service}/{Service}.Infrastructure/DependencyInjection.cs` — external dependencies
+6. Read `src/{Service}/{Service}.Infrastructure/Persistence/Configurations/` — DB schema
+7. Grep for NATS subjects: `signalbeam.` patterns in the service
+8. Read `deploy/charts/{service-name}/values.yaml` — config, env vars, resources
+9. Read `appsettings.json` in the Host project — configuration keys
+
+**API doc (`docs/services/{service-name}/api.md`):**
+1. Read all endpoint files in `src/{Service}/{Service}.Host/Endpoints/`
+2. Read corresponding command/query records for request/response shapes
+3. Read validators for constraints
+4. Extract: method, route, request body, response body, status codes, auth requirements
+
+**Architecture doc (`docs/architecture/technical-architecture.md`):**
+1. Read all `Program.cs` files for service topology
+2. Read `src/SignalBeam.AppHost/` for service discovery and dependencies
+3. Read `infra/terraform/modules/` for infrastructure components
+4. Read `deploy/charts/` for deployment topology
+5. Grep for inter-service communication patterns (HTTP clients, NATS subjects)
+
+**Domain model doc (`docs/architecture/domain-model.md`):**
+1. Read all entities in `src/Shared/SignalBeam.Domain/Entities/`
+2. Read all value objects in `src/Shared/SignalBeam.Domain/ValueObjects/`
+3. Read all domain events in `src/Shared/SignalBeam.Domain/Events/`
+4. Read EF Core configurations for relationships and constraints
+
+**Runbook (`docs/services/{service-name}/runbook.md`):**
+1. Read `Program.cs` for health check endpoints
+2. Read `deploy/charts/{service-name}/values.yaml` for resource limits, probes, env vars
+3. Read `deploy/charts/{service-name}/templates/` for alerts, HPA config
+4. Grep for error codes and error handling patterns
+5. Read integration test factory for dependencies (DB, NATS, Redis, Blob Storage)
+
+**Quickstart (`docs/quickstart.md`):**
+1. Read `src/SignalBeam.AppHost/Program.cs` for local dev setup
+2. Read `docker-compose*.yml` if present
+3. Read `web/package.json` for frontend setup
+4. Read `Directory.Build.props` for SDK requirements
+5. Verify all commands by checking they reference real files/scripts
+
+### Step 3: Generate Documentation
+
+Write the documentation to the appropriate path. Follow these rules:
+
+**Structure:**
+- Use the existing file if updating — preserve sections the user may have manually edited
+- Add a metadata comment at the top: `<!-- Generated from code by /docs on {date}. Do not edit generated sections. -->`
+- Mark auto-generated sections with `<!-- BEGIN GENERATED -->` / `<!-- END GENERATED -->` markers
+- Leave non-generated sections untouched when updating
+
+**Content rules:**
+- Every endpoint, entity, event, and config key must come from actual code you read
+- Include code references: `See: src/DeviceManager/.../RegisterDevice.cs`
+- Use tables for structured data (endpoints, config keys, events)
+- Include Mermaid diagrams for architecture and entity relationships where helpful
+- Keep descriptions concise — one sentence per item unless complexity warrants more
+
+### Step 4: Verify
+
+After generating:
+1. Check all file paths referenced in the doc actually exist
+2. Check all endpoint routes match what's in the code
+3. Check all config keys match what's in appsettings / values.yaml
+4. Report what was generated/updated and word count
+
+## Output Formats
+
+### Service Doc Template
+
+```markdown
+<!-- Generated from code by /docs on {date}. Do not edit generated sections. -->
+# {Service Name}
+
+{One-paragraph description of what this service does.}
+
+## API Endpoints
+
+<!-- BEGIN GENERATED -->
+| Method | Route | Description | Auth |
+|--------|-------|-------------|------|
+| POST | `/api/devices` | Register a new device | API Key |
+| GET | `/api/devices/{id}` | Get device by ID | API Key |
+<!-- END GENERATED -->
+
+## Commands & Queries
+
+<!-- BEGIN GENERATED -->
+### Commands
+| Command | Description | Handler |
+|---------|-------------|---------|
+| `RegisterDeviceCommand` | Registers a new device | `RegisterDeviceHandler` |
+
+### Queries
+| Query | Description | Handler |
+|-------|-------------|---------|
+| `GetDeviceByIdQuery` | Retrieves device by ID | `GetDeviceByIdHandler` |
+<!-- END GENERATED -->
+
+## Domain Events Published
+
+<!-- BEGIN GENERATED -->
+| Event | Trigger | Key Data |
+|-------|---------|----------|
+| `DeviceRegisteredEvent` | Device.Register() | DeviceId, TenantId |
+<!-- END GENERATED -->
+
+## NATS Subjects
+
+<!-- BEGIN GENERATED -->
+| Subject | Type | Direction | Description |
+|---------|------|-----------|-------------|
+| `signalbeam.devices.heartbeat.<deviceId>` | Core NATS | Inbound | Device heartbeats |
+<!-- END GENERATED -->
+
+## Configuration
+
+<!-- BEGIN GENERATED -->
+| Key | Description | Default | Required |
+|-----|-------------|---------|----------|
+| `ConnectionStrings:signalbeam` | PostgreSQL connection | — | Yes |
+<!-- END GENERATED -->
+
+## Dependencies
+
+<!-- BEGIN GENERATED -->
+- **PostgreSQL** — Device state persistence
+- **NATS** — Event publishing and heartbeat ingestion
+- **Valkey** — Caching (optional)
+<!-- END GENERATED -->
+```
+
+### API Doc Template
+
+```markdown
+<!-- Generated from code by /docs on {date}. Do not edit generated sections. -->
+# {Service Name} API Reference
+
+Base URL: `/api/{resource}`
+
+<!-- BEGIN GENERATED -->
+## POST /api/devices
+
+Register a new device.
+
+**Request Body:**
+```json
+{
+  "tenantId": "guid",
+  "name": "string",
+  "metadata": "string | null"
+}
+```
+
+**Response (201):**
+```json
+{
+  "deviceId": "guid",
+  "name": "string",
+  "status": "string",
+  "registeredAt": "datetime"
+}
+```
+
+**Error Codes:**
+| Code | Status | Description |
+|------|--------|-------------|
+| `DEVICE_ALREADY_EXISTS` | 409 | Device with this ID already registered |
+| `TENANT_ID_REQUIRED` | 400 | TenantId is missing or empty |
+
+**Validation Rules:**
+- `tenantId` — Required, non-empty GUID
+- `name` — Required, max 200 characters
+<!-- END GENERATED -->
+```
+
+### Runbook Template
+
+```markdown
+<!-- Generated from code by /docs on {date}. Do not edit generated sections. -->
+# {Service Name} Runbook
+
+## Health Checks
+
+| Endpoint | Type | Description |
+|----------|------|-------------|
+| `/health/live` | Liveness | Process is running |
+| `/health/ready` | Readiness | Dependencies accessible |
+
+## Dependencies
+
+| Dependency | Failure Impact | Recovery |
+|------------|---------------|----------|
+| PostgreSQL | Full outage | Readiness probe fails, pod restarts |
+| NATS | Event publishing stops | Circuit breaker, retries |
+
+## Resource Limits
+
+| Resource | Request | Limit |
+|----------|---------|-------|
+| CPU | 100m | 500m |
+| Memory | 256Mi | 512Mi |
+
+## Common Issues
+
+### {Error Code}
+- **Symptom:** {what the user sees}
+- **Cause:** {root cause}
+- **Resolution:** {steps to fix}
+
+## Alerts
+
+| Alert | Severity | Condition | Runbook Action |
+|-------|----------|-----------|----------------|
+```
+
+## Guidelines
+
+- Accuracy over completeness — skip a section rather than guess
+- Update, don't replace — preserve manually-written content outside generated markers
+- Reference code — every fact should be traceable to a source file
+- Keep it scannable — tables, headers, and short paragraphs over walls of text
+- Date everything — the metadata comment helps track staleness


### PR DESCRIPTION
## Summary
- Add pre-commit and format-on-save hooks for automated code quality
- Add security and git-conventions rules to enforce standards during coding
- Add `/docs` skill for generating documentation from code
- Integrate docs step into the development workflow

## Changes
- **Domain:** No changes
- **Application:** No changes
- **Infrastructure:** No changes
- **Endpoints:** No changes
- **Frontend:** No changes
- **Tests:** No changes
- **Claude Code Config:**
  - `.claude/hooks/pre-commit-lint.sh` — auto-format + lint staged files on commit
  - `.claude/hooks/format-on-save.sh` — auto-format files after Edit/Write
  - `.claude/rules/security.md` — OWASP, injection prevention, secrets, auth, XSS
  - `.claude/rules/git-conventions.md` — branch naming, commit messages, PR standards
  - `.claude/skills/docs/SKILL.md` — generate/update docs from code (service, API, architecture, domain, runbook)
  - `.claude/rules/workflow.md` — added docs step and `/docs` to quick reference
  - `.claude/settings.json` — wired PreToolUse and PostToolUse hooks

## Test Plan
- [ ] Hooks execute correctly on commit and file edit
- [ ] `/docs` skill generates accurate documentation from code
- [ ] Security rule triggers during coding (not just review)
- [ ] Git conventions rule enforces commit message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)