### PR TITLE
add secrets scanning hook and expand security rule

### DIFF
--- a/.claude/hooks/scan-secrets.sh
+++ b/.claude/hooks/scan-secrets.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-commit/pre-push hook: scan staged files for leaked secrets
+# Blocks the commit/push if potential secrets are found
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only intercept git commit and git push commands
+if [[ "$COMMAND" != *"git commit"* && "$COMMAND" != *"git push"* ]]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+ISSUES=()
+
+# Get files to scan: staged for commit, branch diff for push
+if [[ "$COMMAND" == *"git commit"* ]]; then
+  FILES=$(git -C "$PROJECT_DIR" diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
+elif [[ "$COMMAND" == *"git push"* ]]; then
+  FILES=$(git -C "$PROJECT_DIR" diff origin/main...HEAD --name-only 2>/dev/null || true)
+fi
+
+if [[ -z "$FILES" ]]; then
+  exit 0
+fi
+
+# Skip binary files and known safe paths
+SCAN_FILES=""
+while IFS= read -r f; do
+  # Skip binary, lock files, and test fixtures
+  case "$f" in
+    *.png|*.jpg|*.jpeg|*.gif|*.ico|*.woff|*.woff2|*.ttf|*.eot|*.svg) continue ;;
+    **/bin/**|**/obj/**|**/node_modules/**) continue ;;
+    package-lock.json|*.lock) continue ;;
+  esac
+  if [[ -f "$PROJECT_DIR/$f" ]]; then
+    SCAN_FILES="$SCAN_FILES $PROJECT_DIR/$f"
+  fi
+done <<< "$FILES"
+
+if [[ -z "$SCAN_FILES" ]]; then
+  exit 0
+fi
+
+# --- Secret patterns ---
+
+# 1. AWS keys
+if grep -rlP 'AKIA[0-9A-Z]{16}' $SCAN_FILES 2>/dev/null; then
+  ISSUES+=("AWS Access Key ID found")
+fi
+
+# 2. Azure / Entra secrets (client secrets, SAS tokens)
+if grep -rlP '(?i)(client.?secret|azure.?secret)\s*[:=]\s*["\x27][^\s"'\'']{8,}' $SCAN_FILES 2>/dev/null; then
+  ISSUES+=("Azure/Entra client secret found")
+fi
+if grep -rlP 'sig=[A-Za-z0-9%+/=]{20,}' $SCAN_FILES 2>/dev/null; then
+  ISSUES+=("Azure SAS token signature found")
+fi
+
+# 3. Generic private keys
+if grep -rlP '\-\-\-\-\-BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY\-\-\-\-\-' $SCAN_FILES 2>/dev/null; then
+  ISSUES+=("Private key found in source")
+fi
+
+# 4. Connection strings with passwords
+if grep -rlP '(?i)(password|pwd)\s*=' $SCAN_FILES 2>/dev/null | grep -v 'appsettings.Development.json' | grep -v '\.md$' | grep -v 'SKILL.md' | head -1 >/dev/null 2>&1; then
+  # Check it's not a placeholder
+  MATCHES=$(grep -rlP '(?i)(password|pwd)\s*=' $SCAN_FILES 2>/dev/null | grep -v 'appsettings.Development.json' | grep -v '\.md$' | grep -v 'SKILL.md' || true)
+  if [[ -n "$MATCHES" ]]; then
+    # Exclude known safe patterns (empty password, placeholder)
+    REAL_MATCHES=$(grep -lP '(?i)(password|pwd)\s*=\s*["\x27](?![\s"\x27]|your-|placeholder|changeme|\{)' $SCAN_FILES 2>/dev/null | grep -v '\.md$' || true)
+    if [[ -n "$REAL_MATCHES" ]]; then
+      ISSUES+=("Connection string with password found in: $(echo "$REAL_MATCHES" | head -3 | tr '\n' ', ')")
+    fi
+  fi
+fi
+
+# 5. JWT tokens (eyJ... pattern)
+if grep -rlP 'eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}\.' $SCAN_FILES 2>/dev/null; then
+  ISSUES+=("JWT token found in source")
+fi
+
+# 6. SignalBeam-specific: device API keys and registration tokens in source
+if grep -rlP 'sb_device_[a-z0-9]{8}_[A-Za-z0-9]{20,}' $SCAN_FILES 2>/dev/null | grep -v '\.md$' | grep -v 'test' | grep -vi 'Test' | head -1 >/dev/null 2>&1; then
+  ISSUES+=("Device API key (sb_device_*) found in non-test source")
+fi
+if grep -rlP 'sbt_[a-z0-9]{8}_[A-Za-z0-9]{20,}' $SCAN_FILES 2>/dev/null | grep -v '\.md$' | grep -v 'test' | grep -vi 'Test' | head -1 >/dev/null 2>&1; then
+  ISSUES+=("Registration token (sbt_*) found in non-test source")
+fi
+
+# 7. GitHub tokens
+if grep -rlP '(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}' $SCAN_FILES 2>/dev/null; then
+  ISSUES+=("GitHub token found")
+fi
+
+# 8. Generic high-entropy secrets (API_KEY=, SECRET=, TOKEN= with long values)
+if grep -rlP '(?i)(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)\s*[:=]\s*["\x27][A-Za-z0-9+/=_-]{32,}' $SCAN_FILES 2>/dev/null | grep -v '\.md$' | grep -v 'SKILL.md' | head -1 >/dev/null 2>&1; then
+  ISSUES+=("Potential hardcoded secret (long API key/token value) found")
+fi
+
+# 9. .env files being committed
+while IFS= read -r f; do
+  case "$f" in
+    *.env|*.env.local|*.env.production|*.env.staging)
+      ISSUES+=(".env file staged for commit: $f")
+      ;;
+  esac
+done <<< "$FILES"
+
+# --- Report ---
+
+if [[ ${#ISSUES[@]} -gt 0 ]]; then
+  MSG="SECRETS SCAN FAILED — potential secrets detected in staged files:\n"
+  for issue in "${ISSUES[@]}"; do
+    MSG="$MSG\n  - $issue"
+  done
+  MSG="$MSG\n\nReview the flagged files. If these are false positives (test fixtures, documentation), proceed with caution."
+  echo -e "$MSG" >&2
+  exit 2  # Block the commit/push
+fi
+
+exit 0

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -24,13 +24,52 @@ Apply these rules while writing code, not just during review.
 - Never log secrets, tokens, passwords, or PII — use structured logging with explicit fields
 - Connection strings go in `appsettings.json` (dev) or Kubernetes Secrets (deployed)
 - Check: no `password=`, `apikey=`, `secret=`, `bearer` literals in committed code
+- Device API keys (`sb_device_*`) and registration tokens (`sbt_*`) must always be BCrypt-hashed before storage — never store plaintext
 
-## Authentication & Authorization
+## Endpoint Authentication
 
-- Every endpoint must require authentication unless explicitly public
-- Validate `TenantId` on every request — never trust client-provided tenant without verification
-- API key validation must be constant-time to prevent timing attacks
-- JWT tokens: validate issuer, audience, and expiry — never skip validation
+Every new endpoint MUST have authentication. The project uses a layered auth middleware chain:
+
+**DeviceManager** — `UseDeviceAuthentication()` middleware handles: mTLS cert → device API key (`sb_device_*`) → tenant API key → JWT Bearer passthrough
+**BundleOrchestrator** — `UseApiKeyAuthentication()` middleware handles: tenant API key → JWT Bearer passthrough
+**IdentityManager** — JWT Bearer only via standard ASP.NET Core middleware
+
+**Rules:**
+- Every new endpoint requires auth unless it is a health check, metrics, or explicitly public registration endpoint
+- If an endpoint must be public, annotate with `.AllowAnonymous()` and add a code comment explaining why
+- Service-to-service endpoints (e.g., quota checks) that use `.AllowAnonymous()` must validate the caller via other means (internal network, service token)
+- Never add a new service without authentication middleware — TelemetryProcessor and ApiGateway are known gaps to be fixed
+- Path exclusions in middleware (health, metrics, scalar, openapi) must use exact prefix matching, not contains
+
+**When adding a new microservice:**
+1. Add JWT Bearer authentication (`AddAuthentication` + `AddJwtBearer`) in `Program.cs`
+2. Add the appropriate API key middleware (`UseDeviceAuthentication` or `UseApiKeyAuthentication`)
+3. Call `UseAuthentication()` and `UseAuthorization()` in the pipeline
+4. Add `.RequireAuthorization()` to endpoint groups or individual endpoints
+
+## mTLS (Device Authentication)
+
+- Kestrel is configured with `ClientCertificateMode.AllowCertificate` — validation happens in middleware, not at TLS level
+- Certificate validation is done via `IDeviceCertificateValidator` against the DB-backed CA
+- `CheckCertificateRevocation = false` because revocation is DB-backed, not CRL/OCSP
+- When working with certificate endpoints (`/api/certificates/`): only the CA public cert endpoint is `.AllowAnonymous()`
+- Certificate issuance, renewal, and revocation require authentication
+
+## JWT / OIDC Configuration
+
+- Always validate: issuer, audience, lifetime, and signing key (`ValidateIssuer`, `ValidateAudience`, `ValidateLifetime`, `ValidateIssuerSigningKey`)
+- `ClockSkew` maximum: 5 minutes
+- `RequireHttpsMetadata` must be `true` in production — only `false` for local dev
+- Audience is resolved dynamically from `ZITADEL_CONFIG_PATH` at runtime, falling back to `appsettings.json`
+- Never set `ValidateAudience = false` in new services (IdentityManager has this as a known issue)
+
+## API Key Security
+
+- Tenant API keys (MVP): plain config-backed `tenantId:key:scopes` format — acceptable for dev only
+- Device API keys: `sb_device_{prefix}_{secret}` format, BCrypt-hashed (work factor 12)
+- Registration tokens: `sbt_{prefix}_{secret}` format, BCrypt-hashed (work factor 12)
+- Key lookup: use the 8-char prefix for DB lookup, then BCrypt verify the full key
+- Never compare API keys with `==` — use constant-time comparison or BCrypt verify
 
 ## Input Validation
 
@@ -42,8 +81,9 @@ Apply these rules while writing code, not just during review.
 ## Frontend (React/TypeScript)
 
 - Never use `dangerouslySetInnerHTML` without DOMPurify sanitization
-- Never store tokens in `localStorage` for production — use `httpOnly` cookies or secure session storage
-- Sanitize any user-provided content before rendering
+- Auth tokens: Zitadel uses `oidc-client-ts` with automatic silent renew (preferred); Entra uses MSAL with `acquireTokenSilent`
+- API key mode is for development only — production must use OIDC
+- On 401 response: clear auth state and redirect to `/login?redirect={currentPath}`
 - CORS: only allow specific origins, never `*` in production configuration
 
 ## Error Responses

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-lint.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/scan-secrets.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Summary
- Add pre-commit/pre-push secrets scanning hook that blocks commits containing leaked credentials
- Expand security rule with project-specific auth patterns (mTLS, JWT/OIDC, API key security)

## Changes
- **Domain:** No changes
- **Application:** No changes
- **Infrastructure:** No changes
- **Endpoints:** No changes
- **Frontend:** No changes
- **Tests:** No changes
- **Claude Code Config:**
  - `.claude/hooks/scan-secrets.sh` — scans for AWS keys, Azure secrets, private keys, JWT tokens, GitHub tokens, device API keys (`sb_device_*`), registration tokens (`sbt_*`), `.env` files, and high-entropy secrets
  - `.claude/rules/security.md` — expanded with endpoint auth requirements per service, mTLS device auth flow, JWT/OIDC config rules, API key security (BCrypt, prefix lookup), known auth gaps
  - `.claude/settings.json` — wired scan-secrets hook into PreToolUse

## Test Plan
- [ ] Secrets hook blocks commit when a test secret is staged
- [ ] Secrets hook passes cleanly on normal code changes
- [ ] Security rule loads correctly for `src/**/*.cs` and `web/src/**/*.{ts,tsx}` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)