### PR TITLE
add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  # NuGet (.NET)
+  - package-ecosystem: "nuget"
+    directory: "/src"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      microsoft:
+        patterns: ["Microsoft.*"]
+      aspire:
+        patterns: ["Aspire.*"]
+
+  # npm (React frontend)
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Terraform
+  - package-ecosystem: "terraform"
+    directory: "/infra/terraform"
+    schedule:
+      interval: "monthly"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/src"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Enable Dependabot for NuGet, npm, GitHub Actions, Terraform, and Docker ecosystems
- Weekly updates for most ecosystems, monthly for Terraform
- NuGet updates grouped by Microsoft.* and Aspire.* packages

## Test plan
- [ ] Verify Dependabot starts creating PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)