### PR TITLE
add mandatory plan mode to PRD skill

### DIFF
--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prd
 description: Generate a Product Requirements Document through guided discovery questions and codebase analysis. Use for complex features that need structured requirements, success metrics, and technical planning before implementation.
-allowed-tools: Bash, Read, Glob, Grep, Task, AskUserQuestion, Write
+allowed-tools: Bash, Read, Glob, Grep, Task, AskUserQuestion, Write, EnterPlanMode, ExitPlanMode
 user-invocable: true
 ---
 
@@ -16,6 +16,10 @@ Create a detailed, engineer-focused Product Requirements Document through struct
 - `--skip-analysis` — Skip codebase analysis (faster, for greenfield features)
 
 ## Process
+
+### Phase 0: Enter Plan Mode
+
+**Always start by calling `EnterPlanMode` before doing anything else.** PRD generation is a planning activity — it requires codebase exploration, discovery questions, and user alignment before producing output. Plan mode ensures you can explore freely and get user sign-off on the approach before writing the PRD file. Exit plan mode with `ExitPlanMode` only after Phase 4 validation is complete and the user has approved the PRD content.
 
 ### Phase 1: Discovery Questions
 


### PR DESCRIPTION
## Summary
- Adds `EnterPlanMode` and `ExitPlanMode` to the PRD skill's allowed tools
- Adds Phase 0 requiring plan mode entry before starting PRD generation
- Plan mode exits only after Phase 4 validation and user approval

## Test plan
- [ ] Invoke `/prd` and verify it enters plan mode before asking discovery questions
- [ ] Verify plan mode persists through codebase analysis and PRD generation
- [ ] Verify plan mode exits after validation and user approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)