### PR TITLE
add mandatory plan mode to plan-feature skill

### DIFF
--- a/.claude/skills/plan-feature/SKILL.md
+++ b/.claude/skills/plan-feature/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: plan-feature
 description: Break down a feature into a structured plan with acceptance criteria, affected services, and implementation tasks. Use for simple features that don't need a full PRD — or when the user describes what they want to build and needs a task breakdown. For complex features needing full requirements, success metrics, and technical planning, use /prd instead.
-allowed-tools: Read, Glob, Grep, Bash, WebSearch
+allowed-tools: Read, Glob, Grep, Bash, WebSearch, AskUserQuestion, EnterPlanMode, ExitPlanMode
+model: claude-opus-4-6
 user-invocable: true
 ---
 
@@ -10,6 +11,10 @@ user-invocable: true
 When the user describes a feature they want to build, produce a structured feature plan. Explore the codebase first to ground the plan in what already exists.
 
 ## Process
+
+### Phase 0: Enter Plan Mode
+
+**Always start by calling `EnterPlanMode` before doing anything else.** Feature planning is a planning activity — it requires codebase exploration, scope clarification, and user alignment before producing the plan. Plan mode ensures you can explore freely and get user sign-off on the approach. Exit plan mode with `ExitPlanMode` only after the plan is complete and the user has approved it.
 
 1. **Clarify scope** — Ask the user if the feature description is ambiguous. Identify which microservice(s) are affected.
 2. **Explore existing code** — Search for related entities, handlers, endpoints, and tests that the feature touches or extends.


### PR DESCRIPTION
## Summary
- Add `EnterPlanMode`/`ExitPlanMode` to plan-feature skill's allowed tools
- Set model to `claude-opus-4-6` for higher quality planning output
- Add Phase 0 instruction matching the PRD skill's plan mode pattern

## Test plan
- [ ] Run `/plan-feature` and verify it enters plan mode before exploring
- [ ] Verify plan mode exits after user approves the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)