### PR TITLE
add EdgeAgent self-registration, key lifecycle, and real metrics

### DIFF
--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/ClaimDeviceApiKey.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/ClaimDeviceApiKey.cs
@@ -1,0 +1,181 @@
+using SignalBeam.DeviceManager.Application.Repositories;
+using SignalBeam.Domain.Entities;
+using SignalBeam.Domain.Enums;
+using SignalBeam.Domain.ValueObjects;
+using SignalBeam.Shared.Infrastructure.Authentication;
+using SignalBeam.Shared.Infrastructure.Results;
+
+namespace SignalBeam.DeviceManager.Application.Commands;
+
+/// <summary>
+/// Command for a device to claim its API key exactly once after admin approval.
+/// At this point in the lifecycle the device has no API key, so the claim is
+/// authenticated by the registration token the device used to register — which is
+/// BCrypt-verified and bound to this specific device.
+/// </summary>
+public record ClaimDeviceApiKeyCommand(Guid DeviceId, string RegistrationToken);
+
+/// <summary>
+/// Response carrying the freshly generated API key. The plaintext key is returned
+/// only here and never again.
+/// </summary>
+public record ClaimDeviceApiKeyResponse(
+    Guid DeviceId,
+    string ApiKey,
+    string KeyPrefix,
+    DateTimeOffset? ExpiresAt);
+
+/// <summary>
+/// Handler for <see cref="ClaimDeviceApiKeyCommand"/>.
+/// </summary>
+public class ClaimDeviceApiKeyHandler
+{
+    private const int ApiKeyExpirationDays = 90;
+
+    private readonly IDeviceRepository _deviceRepository;
+    private readonly IDeviceApiKeyRepository _apiKeyRepository;
+    private readonly IDeviceRegistrationTokenRepository _tokenRepository;
+    private readonly IDeviceApiKeyService _apiKeyService;
+    private readonly IRegistrationTokenService _tokenService;
+
+    public ClaimDeviceApiKeyHandler(
+        IDeviceRepository deviceRepository,
+        IDeviceApiKeyRepository apiKeyRepository,
+        IDeviceRegistrationTokenRepository tokenRepository,
+        IDeviceApiKeyService apiKeyService,
+        IRegistrationTokenService tokenService)
+    {
+        _deviceRepository = deviceRepository;
+        _apiKeyRepository = apiKeyRepository;
+        _tokenRepository = tokenRepository;
+        _apiKeyService = apiKeyService;
+        _tokenService = tokenService;
+    }
+
+    public async Task<Result<ClaimDeviceApiKeyResponse>> Handle(
+        ClaimDeviceApiKeyCommand command,
+        CancellationToken cancellationToken)
+    {
+        var deviceId = new DeviceId(command.DeviceId);
+        var device = await _deviceRepository.GetByIdAsync(deviceId, cancellationToken);
+
+        if (device is null)
+        {
+            return Result.Failure<ClaimDeviceApiKeyResponse>(Error.NotFound(
+                "DEVICE_NOT_FOUND",
+                $"Device with ID {command.DeviceId} not found."));
+        }
+
+        if (device.RegistrationStatus != DeviceRegistrationStatus.Approved)
+        {
+            return Result.Failure<ClaimDeviceApiKeyResponse>(Error.Forbidden(
+                "DEVICE_NOT_APPROVED",
+                "Device is not approved; an API key cannot be claimed yet."));
+        }
+
+        // One-time semantics: once claimed, force the device through key rotation instead.
+        if (device.KeyClaimedAt is not null)
+        {
+            return Result.Failure<ClaimDeviceApiKeyResponse>(Error.Conflict(
+                "KEY_ALREADY_CLAIMED",
+                "The API key for this device has already been claimed. Use key rotation to obtain a new key."));
+        }
+
+        // Authenticate the claim with the registration token bound to this device.
+        var tokenValidation = await ValidateClaimTokenAsync(command.RegistrationToken, device, cancellationToken);
+        if (tokenValidation.IsFailure)
+        {
+            return Result.Failure<ClaimDeviceApiKeyResponse>(tokenValidation.Error!);
+        }
+
+        // Supersede any pre-existing active key (e.g. one generated for the admin at approval time)
+        // so exactly one key — the device's claimed key — is active.
+        var existingKeys = await _apiKeyRepository.GetActiveByDeviceIdAsync(deviceId, cancellationToken);
+        foreach (var existingKey in existingKeys)
+        {
+            existingKey.Revoke(DateTimeOffset.UtcNow);
+            _apiKeyRepository.Update(existingKey);
+        }
+
+        var (plainTextKey, keyHash, keyPrefix) = _apiKeyService.GenerateApiKey(deviceId);
+        var createdAt = DateTimeOffset.UtcNow;
+        var expiresAt = createdAt.AddDays(ApiKeyExpirationDays);
+
+        var apiKey = DeviceApiKey.Create(
+            deviceId,
+            keyHash,
+            keyPrefix,
+            createdAt,
+            expiresAt,
+            createdBy: "device-claim");
+
+        await _apiKeyRepository.AddAsync(apiKey, cancellationToken);
+
+        device.MarkKeyClaimed(createdAt);
+
+        await _deviceRepository.SaveChangesAsync(cancellationToken);
+        await _apiKeyRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<ClaimDeviceApiKeyResponse>.Success(new ClaimDeviceApiKeyResponse(
+            device.Id.Value,
+            plainTextKey,
+            keyPrefix,
+            expiresAt));
+    }
+
+    private async Task<Result> ValidateClaimTokenAsync(
+        string tokenString,
+        Device device,
+        CancellationToken cancellationToken)
+    {
+        // Expected format: sbt_{prefix}_{secret}
+        if (string.IsNullOrWhiteSpace(tokenString))
+        {
+            return Result.Failure(Error.Unauthorized(
+                "RegistrationToken.InvalidFormat",
+                "Registration token is required."));
+        }
+
+        var parts = tokenString.Split('_');
+        if (parts.Length != 3 || parts[0] != "sbt")
+        {
+            return Result.Failure(Error.Unauthorized(
+                "RegistrationToken.InvalidFormat",
+                "Registration token has invalid format."));
+        }
+
+        var tokenPrefix = $"sbt_{parts[1]}";
+        var token = await _tokenRepository.GetByPrefixAsync(tokenPrefix, cancellationToken);
+
+        if (token is null)
+        {
+            return Result.Failure(Error.Unauthorized(
+                "RegistrationToken.Invalid",
+                "Registration token is invalid."));
+        }
+
+        if (token.TenantId != device.TenantId)
+        {
+            return Result.Failure(Error.Unauthorized(
+                "RegistrationToken.Invalid",
+                "Registration token is invalid."));
+        }
+
+        if (!_tokenService.ValidateToken(tokenString, token.TokenHash))
+        {
+            return Result.Failure(Error.Unauthorized(
+                "RegistrationToken.Invalid",
+                "Registration token is invalid."));
+        }
+
+        // Bind the claim to the device that actually used this token during registration.
+        if (token.UsedByDeviceId is null || token.UsedByDeviceId != device.Id)
+        {
+            return Result.Failure(Error.Unauthorized(
+                "RegistrationToken.DeviceMismatch",
+                "Registration token was not used by this device."));
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/ClaimDeviceApiKey.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/ClaimDeviceApiKey.cs
@@ -113,8 +113,10 @@ public class ClaimDeviceApiKeyHandler
 
         device.MarkKeyClaimed(createdAt);
 
+        // The device and API key repositories share one DbContext, so a single SaveChanges
+        // commits the revoked old keys, the new key, and the KeyClaimedAt marker atomically —
+        // the device can't end up marked-claimed without a usable key.
         await _deviceRepository.SaveChangesAsync(cancellationToken);
-        await _apiKeyRepository.SaveChangesAsync(cancellationToken);
 
         return Result<ClaimDeviceApiKeyResponse>.Success(new ClaimDeviceApiKeyResponse(
             device.Id.Value,
@@ -174,6 +176,15 @@ public class ClaimDeviceApiKeyHandler
             return Result.Failure(Error.Unauthorized(
                 "RegistrationToken.DeviceMismatch",
                 "Registration token was not used by this device."));
+        }
+
+        // Honour explicit revocation and expiry. We do NOT use token.IsValid here because its
+        // MaxUses check is already satisfied (consumed) by registration — the claim happens after.
+        if (token.IsRevoked || token.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            return Result.Failure(Error.Unauthorized(
+                "RegistrationToken.Expired",
+                "Registration token has been revoked or has expired."));
         }
 
         return Result.Success();

--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/GenerateRegistrationToken.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/GenerateRegistrationToken.cs
@@ -16,7 +16,8 @@ public record GenerateRegistrationTokenCommand(
     DateTimeOffset? ExpiresAt = null,
     int ValidityDays = 30,
     string? CreatedBy = null,
-    string? Description = null);
+    string? Description = null,
+    bool AutoApprove = false);
 
 /// <summary>
 /// Response containing the generated registration token.
@@ -68,7 +69,8 @@ public class GenerateRegistrationTokenHandler
                 expiresAt,
                 command.CreatedBy,
                 command.Description,
-                command.MaxUses);
+                command.MaxUses,
+                command.AutoApprove);
 
             // Save to database
             await _tokenRepository.AddAsync(token, cancellationToken);

--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/RegisterDevice.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/RegisterDevice.cs
@@ -67,6 +67,7 @@ public class RegisterDeviceHandler
         }
 
         // Validate registration token if provided
+        DeviceRegistrationToken? validatedToken = null;
         if (!string.IsNullOrEmpty(command.RegistrationToken))
         {
             var tokenValidation = await ValidateRegistrationTokenAsync(
@@ -79,6 +80,8 @@ public class RegisterDeviceHandler
             {
                 return Result.Failure<RegisterDeviceResponse>(tokenValidation.Error!);
             }
+
+            validatedToken = tokenValidation.Value;
         }
 
         // Check if device already exists
@@ -100,6 +103,13 @@ public class RegisterDeviceHandler
             DateTimeOffset.UtcNow,
             command.Metadata);
 
+        // Zero-touch provisioning: a trusted (auto-approve) token approves on registration,
+        // so the device can immediately claim its API key without a manual approval step.
+        if (validatedToken?.AutoApprove == true)
+        {
+            device.ApproveRegistration(DateTimeOffset.UtcNow);
+        }
+
         // Save to repository
         await _deviceRepository.AddAsync(device, cancellationToken);
         await _deviceRepository.SaveChangesAsync(cancellationToken);
@@ -112,7 +122,7 @@ public class RegisterDeviceHandler
             device.RegisteredAt));
     }
 
-    private async Task<Result> ValidateRegistrationTokenAsync(
+    private async Task<Result<DeviceRegistrationToken>> ValidateRegistrationTokenAsync(
         string tokenString,
         TenantId tenantId,
         DeviceId deviceId,
@@ -122,7 +132,7 @@ public class RegisterDeviceHandler
         var parts = tokenString.Split('_');
         if (parts.Length != 3 || parts[0] != "sbt")
         {
-            return Result.Failure(Error.Validation(
+            return Result.Failure<DeviceRegistrationToken>(Error.Validation(
                 "RegistrationToken.InvalidFormat",
                 "Registration token has invalid format."));
         }
@@ -134,7 +144,7 @@ public class RegisterDeviceHandler
 
         if (token == null)
         {
-            return Result.Failure(Error.NotFound(
+            return Result.Failure<DeviceRegistrationToken>(Error.NotFound(
                 "RegistrationToken.NotFound",
                 "Registration token not found or has expired."));
         }
@@ -142,7 +152,7 @@ public class RegisterDeviceHandler
         // Validate token belongs to correct tenant
         if (token.TenantId != tenantId)
         {
-            return Result.Failure(Error.Validation(
+            return Result.Failure<DeviceRegistrationToken>(Error.Validation(
                 "RegistrationToken.InvalidTenant",
                 "Registration token does not belong to this tenant."));
         }
@@ -150,7 +160,7 @@ public class RegisterDeviceHandler
         // Validate token hash
         if (!_tokenService.ValidateToken(tokenString, token.TokenHash))
         {
-            return Result.Failure(Error.Validation(
+            return Result.Failure<DeviceRegistrationToken>(Error.Validation(
                 "RegistrationToken.Invalid",
                 "Registration token is invalid."));
         }
@@ -158,7 +168,7 @@ public class RegisterDeviceHandler
         // Validate token is not used and not expired
         if (!token.IsValid)
         {
-            return Result.Failure(Error.Validation(
+            return Result.Failure<DeviceRegistrationToken>(Error.Validation(
                 "RegistrationToken.Expired",
                 "Registration token has expired or has already been used."));
         }
@@ -168,6 +178,6 @@ public class RegisterDeviceHandler
         await _tokenRepository.UpdateAsync(token, cancellationToken);
         await _tokenRepository.SaveChangesAsync(cancellationToken);
 
-        return Result.Success();
+        return Result<DeviceRegistrationToken>.Success(token);
     }
 }

--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/SignDeviceCsr.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/SignDeviceCsr.cs
@@ -1,0 +1,109 @@
+using SignalBeam.DeviceManager.Application.Repositories;
+using SignalBeam.DeviceManager.Application.Services;
+using SignalBeam.Domain.Entities;
+using SignalBeam.Domain.Enums;
+using SignalBeam.Domain.ValueObjects;
+using SignalBeam.Shared.Infrastructure.Results;
+
+namespace SignalBeam.DeviceManager.Application.Commands;
+
+/// <summary>
+/// Command to sign a device-generated PKCS#10 CSR and issue an mTLS client certificate.
+/// The device keeps its private key, so the response carries no private key.
+/// </summary>
+public record SignDeviceCsrCommand(
+    Guid DeviceId,
+    string Csr,
+    int ValidityDays = 90);
+
+public record SignDeviceCsrResponse(
+    Guid DeviceId,
+    string CertificatePem,
+    string CaCertificatePem,
+    string SerialNumber,
+    string Fingerprint,
+    DateTimeOffset IssuedAt,
+    DateTimeOffset ExpiresAt);
+
+public class SignDeviceCsrHandler
+{
+    private readonly IDeviceRepository _deviceRepository;
+    private readonly IDeviceCertificateRepository _certificateRepository;
+    private readonly ICertificateAuthorityService _caService;
+
+    public SignDeviceCsrHandler(
+        IDeviceRepository deviceRepository,
+        IDeviceCertificateRepository certificateRepository,
+        ICertificateAuthorityService caService)
+    {
+        _deviceRepository = deviceRepository;
+        _certificateRepository = certificateRepository;
+        _caService = caService;
+    }
+
+    public async Task<Result<SignDeviceCsrResponse>> Handle(
+        SignDeviceCsrCommand command,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(command.Csr))
+        {
+            return Result.Failure<SignDeviceCsrResponse>(Error.Validation(
+                "CSR_REQUIRED", "A certificate signing request (CSR) is required."));
+        }
+
+        var deviceId = new DeviceId(command.DeviceId);
+        var device = await _deviceRepository.GetByIdAsync(deviceId, cancellationToken);
+
+        if (device is null)
+        {
+            return Result.Failure<SignDeviceCsrResponse>(Error.NotFound(
+                "DEVICE_NOT_FOUND", $"Device with ID {command.DeviceId} not found."));
+        }
+
+        if (device.RegistrationStatus != DeviceRegistrationStatus.Approved)
+        {
+            return Result.Failure<SignDeviceCsrResponse>(Error.Forbidden(
+                "DEVICE_NOT_APPROVED", "Only approved devices can receive certificates."));
+        }
+
+        var existingCert = await _certificateRepository.GetActiveByDeviceIdAsync(deviceId, cancellationToken);
+        if (existingCert is not null)
+        {
+            return Result.Failure<SignDeviceCsrResponse>(Error.Conflict(
+                "CERTIFICATE_ALREADY_EXISTS",
+                $"Device {command.DeviceId} already has an active certificate. Use renew instead."));
+        }
+
+        var certificateResult = await _caService.SignCsrAsync(
+            deviceId, command.Csr, command.ValidityDays, cancellationToken);
+
+        if (certificateResult.IsFailure)
+        {
+            return Result.Failure<SignDeviceCsrResponse>(certificateResult.Error!);
+        }
+
+        var cert = certificateResult.Value;
+
+        var deviceCert = DeviceCertificate.Create(
+            deviceId,
+            cert.CertificatePem,
+            cert.SerialNumber,
+            cert.Fingerprint,
+            cert.IssuedAt,
+            cert.ExpiresAt,
+            subject: $"CN=device-{deviceId.Value}, O=SignalBeam",
+            type: CertificateType.Device);
+
+        await _certificateRepository.AddAsync(deviceCert, cancellationToken);
+        await _certificateRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<SignDeviceCsrResponse>.Success(new SignDeviceCsrResponse(
+            device.Id.Value,
+            cert.CertificatePem,
+            cert.CaCertificatePem,
+            cert.SerialNumber,
+            cert.Fingerprint,
+            cert.IssuedAt,
+            cert.ExpiresAt));
+    }
+}

--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/SignDeviceCsr.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/SignDeviceCsr.cs
@@ -27,6 +27,8 @@ public record SignDeviceCsrResponse(
 
 public class SignDeviceCsrHandler
 {
+    private const int MaxValidityDays = 365;
+
     private readonly IDeviceRepository _deviceRepository;
     private readonly IDeviceCertificateRepository _certificateRepository;
     private readonly ICertificateAuthorityService _caService;
@@ -74,8 +76,11 @@ public class SignDeviceCsrHandler
                 $"Device {command.DeviceId} already has an active certificate. Use renew instead."));
         }
 
+        // Clamp caller-supplied validity to a sane bound so a device can't request a long-lived cert.
+        var validityDays = Math.Clamp(command.ValidityDays, 1, MaxValidityDays);
+
         var certificateResult = await _caService.SignCsrAsync(
-            deviceId, command.Csr, command.ValidityDays, cancellationToken);
+            deviceId, command.Csr, validityDays, cancellationToken);
 
         if (certificateResult.IsFailure)
         {

--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/Queries/GetRegistrationStatus.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/Queries/GetRegistrationStatus.cs
@@ -16,7 +16,8 @@ public record GetRegistrationStatusQuery(Guid DeviceId);
 public record GetRegistrationStatusResponse(
     string Status,
     string? ApiKey = null,
-    DateTimeOffset? ApiKeyExpiresAt = null);
+    DateTimeOffset? ApiKeyExpiresAt = null,
+    bool KeyClaimAvailable = false);
 
 /// <summary>
 /// Handler for GetRegistrationStatusQuery.
@@ -77,7 +78,8 @@ public class GetRegistrationStatusHandler
 
         return Result<GetRegistrationStatusResponse>.Success(new GetRegistrationStatusResponse(
             device.RegistrationStatus.ToString(),
-            null, // API key not returned for security
-            expiresAt));
+            null, // API key not returned here — the device retrieves it once via the claim-key endpoint
+            expiresAt,
+            device.IsKeyClaimAvailable));
     }
 }

--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/Services/ICertificateAuthorityService.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/Services/ICertificateAuthorityService.cs
@@ -21,6 +21,16 @@ public interface ICertificateAuthorityService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Signs a device-generated PKCS#10 CSR. The device keeps its private key, so the returned
+    /// <see cref="IssuedCertificate.PrivateKeyPem"/> is empty.
+    /// </summary>
+    Task<Result<IssuedCertificate>> SignCsrAsync(
+        DeviceId deviceId,
+        string csrPem,
+        int validityDays = 90,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the CA certificate (for distribution to devices).
     /// </summary>
     Task<string> GetCaCertificateAsync(CancellationToken cancellationToken = default);

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/CertificateEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/CertificateEndpoints.cs
@@ -6,6 +6,11 @@ using SignalBeam.DeviceManager.Application.Services;
 namespace SignalBeam.DeviceManager.Host.Endpoints;
 
 /// <summary>
+/// Request body for signing a device-generated CSR.
+/// </summary>
+public record SignDeviceCsrRequest(string Csr);
+
+/// <summary>
 /// Certificate management API endpoints for mTLS.
 /// </summary>
 public static class CertificateEndpoints
@@ -23,6 +28,12 @@ public static class CertificateEndpoints
             .WithName("IssueCertificate")
             .WithSummary("Issue a new certificate for an approved device")
             .WithDescription("Generates and issues a new mTLS client certificate for an approved device.");
+
+        group.MapPost("/{deviceId:guid}/sign-csr", SignDeviceCsr)
+            .WithName("SignDeviceCsr")
+            .WithSummary("Sign a device-generated CSR")
+            .WithDescription("Signs a device-generated PKCS#10 CSR and issues an mTLS client certificate. " +
+                "The device keeps its private key — only the public key is certified.");
 
         group.MapPost("/{serialNumber}/renew", RenewCertificate)
             .WithName("RenewCertificate")
@@ -59,6 +70,24 @@ public static class CertificateEndpoints
         CancellationToken cancellationToken = default)
     {
         var command = new IssueCertificateCommand(deviceId, validityDays);
+        var result = await handler.Handle(command, cancellationToken);
+
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : Results.BadRequest(new { error = result.Error!.Code, message = result.Error.Message });
+    }
+
+    /// <summary>
+    /// Signs a device-generated CSR and issues a client certificate.
+    /// </summary>
+    private static async Task<IResult> SignDeviceCsr(
+        Guid deviceId,
+        [FromBody] SignDeviceCsrRequest request,
+        [FromServices] SignDeviceCsrHandler handler,
+        [FromQuery] int validityDays = 90,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new SignDeviceCsrCommand(deviceId, request.Csr, validityDays);
         var result = await handler.Handle(command, cancellationToken);
 
         return result.IsSuccess

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
@@ -2,6 +2,7 @@ using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Queries;
 using SignalBeam.DeviceManager.Infrastructure.Queries;
 using SignalBeam.Domain.Enums;
+using SignalBeam.Shared.Infrastructure.Authentication;
 using SignalBeam.Shared.Infrastructure.Results;
 using Microsoft.AspNetCore.Mvc;
 
@@ -519,9 +520,21 @@ public static class DeviceEndpoints
 
     private static async Task<IResult> RotateDeviceApiKey(
         Guid deviceId,
+        HttpContext httpContext,
         [FromServices] GenerateDeviceApiKeyHandler handler,
         CancellationToken cancellationToken)
     {
+        // Object-level authorization: a device may only rotate its OWN key. The middleware
+        // authenticated the caller via its current device API key and set the device_id claim;
+        // reject if it doesn't match the route to prevent one device rotating another's key.
+        var callerDeviceId = httpContext.User.FindFirst(AuthenticationConstants.DeviceIdClaimType)?.Value;
+        if (!Guid.TryParse(callerDeviceId, out var authenticatedDeviceId) || authenticatedDeviceId != deviceId)
+        {
+            return Results.Json(
+                new { error = "FORBIDDEN", message = "A device may only rotate its own API key." },
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
         // Rotation = generate a fresh key and revoke the old ones.
         var command = new GenerateDeviceApiKeyCommand(deviceId, ExpirationDays: 90, RevokeExistingKeys: true);
         var result = await handler.Handle(command, cancellationToken);

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
@@ -125,6 +125,12 @@ public static class DeviceEndpoints
             .WithSummary("Generate device API key")
             .WithDescription("Generates a new API key for a device (for key rotation).");
 
+        group.MapPost("/{deviceId:guid}/rotate-key", RotateDeviceApiKey)
+            .WithName("RotateDeviceApiKey")
+            .WithSummary("Rotate device API key")
+            .WithDescription("Rotates the device API key: issues a new key and revokes existing ones. " +
+                "Called by the agent with its current (soon-to-expire) key before expiry.");
+
         group.MapDelete("/api-keys/{apiKeyId:guid}", RevokeDeviceApiKey)
             .WithName("RevokeDeviceApiKey")
             .WithSummary("Revoke device API key")
@@ -510,6 +516,28 @@ public static class DeviceEndpoints
         message = error.Message,
         type = error.Type.ToString()
     };
+
+    private static async Task<IResult> RotateDeviceApiKey(
+        Guid deviceId,
+        [FromServices] GenerateDeviceApiKeyHandler handler,
+        CancellationToken cancellationToken)
+    {
+        // Rotation = generate a fresh key and revoke the old ones.
+        var command = new GenerateDeviceApiKeyCommand(deviceId, ExpirationDays: 90, RevokeExistingKeys: true);
+        var result = await handler.Handle(command, cancellationToken);
+
+        return result.IsSuccess
+            ? Results.Ok(new
+            {
+                deviceId = result.Value!.DeviceId,
+                apiKey = result.Value.ApiKey,
+                keyPrefix = result.Value.KeyPrefix,
+                createdAt = result.Value.CreatedAt,
+                expiresAt = result.Value.ExpiresAt,
+                message = "API key rotated successfully. Save the key - it will not be shown again."
+            })
+            : Results.BadRequest(ToError(result.Error!));
+    }
 
     private static async Task<IResult> RevokeDeviceApiKey(
         Guid apiKeyId,

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
@@ -2,9 +2,15 @@ using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Queries;
 using SignalBeam.DeviceManager.Infrastructure.Queries;
 using SignalBeam.Domain.Enums;
+using SignalBeam.Shared.Infrastructure.Results;
 using Microsoft.AspNetCore.Mvc;
 
 namespace SignalBeam.DeviceManager.Host.Endpoints;
+
+/// <summary>
+/// Request body for the one-time device API key claim.
+/// </summary>
+public record ClaimDeviceApiKeyRequest(string RegistrationToken);
 
 /// <summary>
 /// Device API endpoints.
@@ -105,6 +111,14 @@ public static class DeviceEndpoints
             .WithName("RejectDeviceRegistration")
             .WithSummary("Reject device registration")
             .WithDescription("Rejects a pending device registration.");
+
+        group.MapPost("/{deviceId:guid}/claim-key", ClaimDeviceApiKey)
+            .WithName("ClaimDeviceApiKey")
+            .WithSummary("Claim device API key (one-time)")
+            .WithDescription("Allows an approved device to retrieve its API key exactly once, " +
+                "authenticated by the registration token it registered with. Part of the registration " +
+                "handshake — reachable before the device holds an API key.")
+            .AllowAnonymous();
 
         group.MapPost("/{deviceId:guid}/api-keys", GenerateDeviceApiKey)
             .WithName("GenerateDeviceApiKey")
@@ -461,6 +475,41 @@ public static class DeviceEndpoints
                 type = result.Error.Type.ToString()
             });
     }
+
+    private static async Task<IResult> ClaimDeviceApiKey(
+        Guid deviceId,
+        [FromBody] ClaimDeviceApiKeyRequest request,
+        [FromServices] ClaimDeviceApiKeyHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new ClaimDeviceApiKeyCommand(deviceId, request.RegistrationToken);
+        var result = await handler.Handle(command, cancellationToken);
+
+        return result.IsSuccess
+            ? Results.Ok(new
+            {
+                deviceId = result.Value!.DeviceId,
+                apiKey = result.Value.ApiKey,
+                keyPrefix = result.Value.KeyPrefix,
+                expiresAt = result.Value.ExpiresAt,
+                message = "API key claimed successfully. Save the key - it will not be shown again."
+            })
+            : result.Error!.Type switch
+            {
+                ErrorType.NotFound => Results.NotFound(ToError(result.Error)),
+                ErrorType.Unauthorized => Results.Json(ToError(result.Error), statusCode: StatusCodes.Status401Unauthorized),
+                ErrorType.Forbidden => Results.Json(ToError(result.Error), statusCode: StatusCodes.Status403Forbidden),
+                ErrorType.Conflict => Results.Conflict(ToError(result.Error)),
+                _ => Results.BadRequest(ToError(result.Error))
+            };
+    }
+
+    private static object ToError(Error error) => new
+    {
+        error = error.Code,
+        message = error.Message,
+        type = error.Type.ToString()
+    };
 
     private static async Task<IResult> RevokeDeviceApiKey(
         Guid apiKeyId,

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
@@ -176,6 +176,7 @@ builder.Services.AddSingleton<CertificateMetrics>();
 
 // Register certificate command and query handlers
 builder.Services.AddScoped<IssueCertificateHandler>();
+builder.Services.AddScoped<SignDeviceCsrHandler>();
 builder.Services.AddScoped<RenewCertificateHandler>();
 builder.Services.AddScoped<RevokeCertificateHandler>();
 builder.Services.AddScoped<GetDeviceCertificatesHandler>();

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
@@ -149,6 +149,7 @@ builder.Services.AddScoped<BulkRemoveDeviceTagsHandler>();
 builder.Services.AddScoped<ApproveDeviceRegistrationHandler>();
 builder.Services.AddScoped<RejectDeviceRegistrationHandler>();
 builder.Services.AddScoped<GenerateDeviceApiKeyHandler>();
+builder.Services.AddScoped<ClaimDeviceApiKeyHandler>();
 builder.Services.AddScoped<RevokeDeviceApiKeyHandler>();
 
 builder.Services.AddScoped<GetDevicesHandler>();

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/CertificateAuthority/CertificateAuthorityService.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/CertificateAuthority/CertificateAuthorityService.cs
@@ -125,6 +125,55 @@ public class CertificateAuthorityService : ICertificateAuthorityService
         }
     }
 
+    public async Task<Result<IssuedCertificate>> SignCsrAsync(
+        DeviceId deviceId,
+        string csrPem,
+        int validityDays = 90,
+        CancellationToken cancellationToken = default)
+    {
+        await InitializeAsync(cancellationToken);
+
+        try
+        {
+            var caCertificatePem = await _caKeyStore.GetCaCertificateAsync(cancellationToken);
+            var caPrivateKeyPem = await _caKeyStore.GetCaPrivateKeyAsync(cancellationToken);
+
+            var serialNumber = GenerateSerialNumber();
+
+            var signedCertPem = _certificateGenerator.SignCertificateSigningRequest(
+                csrPem,
+                caPrivateKeyPem,
+                caCertificatePem,
+                serialNumber,
+                validityDays);
+
+            var fingerprint = _certificateGenerator.CalculateFingerprint(signedCertPem);
+            var issuedAt = DateTimeOffset.UtcNow;
+            var expiresAt = issuedAt.AddDays(validityDays);
+
+            _logger.LogInformation(
+                "Signed CSR for device {DeviceId}. Serial: {SerialNumber}, Expires: {ExpiresAt}",
+                deviceId.Value, serialNumber, expiresAt);
+
+            // The device holds its own private key — never returned here.
+            return Result<IssuedCertificate>.Success(new IssuedCertificate(
+                signedCertPem,
+                string.Empty,
+                caCertificatePem,
+                serialNumber,
+                fingerprint,
+                issuedAt,
+                expiresAt));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to sign CSR for device {DeviceId}", deviceId.Value);
+            return Result.Failure<IssuedCertificate>(Error.Failure(
+                "CSR_SIGNING_FAILED",
+                $"Failed to sign certificate signing request: {ex.Message}"));
+        }
+    }
+
     public async Task<string> GetCaCertificateAsync(CancellationToken cancellationToken = default)
     {
         await InitializeAsync(cancellationToken);

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/CertificateAuthority/ICertificateGenerator.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/CertificateAuthority/ICertificateGenerator.cs
@@ -33,6 +33,19 @@ public interface ICertificateGenerator
     string SignCertificate(string certificateRequest, string caPrivateKeyPem, string caCertificatePem);
 
     /// <summary>
+    /// Signs a device-generated PKCS#10 certificate signing request (CSR) with the CA key.
+    /// The device keeps its private key; only its public key and subject are taken from the CSR.
+    /// CA-controlled extensions (clientAuth EKU, key usage) are always applied — any extensions
+    /// in the CSR are ignored.
+    /// </summary>
+    string SignCertificateSigningRequest(
+        string csrPem,
+        string caPrivateKeyPem,
+        string caCertificatePem,
+        string serialNumberHex,
+        int validityDays);
+
+    /// <summary>
     /// Calculates the SHA-256 fingerprint of a certificate.
     /// </summary>
     /// <param name="certificatePem">Certificate in PEM format.</param>

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/CertificateAuthority/X509CertificateGenerator.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/CertificateAuthority/X509CertificateGenerator.cs
@@ -155,6 +155,48 @@ public class X509CertificateGenerator : ICertificateGenerator
         return ExportCertificateToPem(signedCert);
     }
 
+    public string SignCertificateSigningRequest(
+        string csrPem,
+        string caPrivateKeyPem,
+        string caCertificatePem,
+        string serialNumberHex,
+        int validityDays)
+    {
+        using var caCert = X509Certificate2.CreateFromPem(caCertificatePem, caPrivateKeyPem);
+
+        // Load the device's PKCS#10 CSR. Default options deliberately skip any extensions in the
+        // CSR — the CA dictates them — so we read only the subject and public key.
+        var csr = CertificateRequest.LoadSigningRequestPem(
+            csrPem,
+            HashAlgorithmName.SHA256,
+            CertificateRequestLoadOptions.Default,
+            RSASignaturePadding.Pkcs1);
+
+        // Apply CA-controlled extensions for a TLS client certificate.
+        csr.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(false, false, 0, critical: true));
+        csr.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+                critical: true));
+        csr.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(
+                new OidCollection { new Oid("1.3.6.1.5.5.7.3.2") }, // clientAuth
+                critical: true));
+        csr.CertificateExtensions.Add(
+            new X509SubjectKeyIdentifierExtension(csr.PublicKey, critical: false));
+        csr.CertificateExtensions.Add(
+            X509AuthorityKeyIdentifierExtension.CreateFromCertificate(
+                caCert, includeKeyIdentifier: true, includeIssuerAndSerial: false));
+
+        var notBefore = DateTimeOffset.UtcNow.AddDays(-1);
+        var notAfter = DateTimeOffset.UtcNow.AddDays(validityDays);
+        var serialBytes = Convert.FromHexString(serialNumberHex);
+
+        using var signedCert = csr.Create(caCert, notBefore, notAfter, serialBytes);
+        return ExportCertificateToPem(signedCert);
+    }
+
     public string CalculateFingerprint(string certificatePem)
     {
         using var cert = X509Certificate2.CreateFromPem(certificatePem);

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Configurations/DeviceConfiguration.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Configurations/DeviceConfiguration.cs
@@ -53,6 +53,10 @@ public class DeviceConfiguration : IEntityTypeConfiguration<Device>
             .HasDefaultValue(Domain.Enums.DeviceRegistrationStatus.Pending)
             .IsRequired();
 
+        // One-time API key claim marker (set when the device claims its key after approval)
+        builder.Property(d => d.KeyClaimedAt)
+            .HasColumnName("key_claimed_at");
+
         // Timestamps
         builder.Property(d => d.LastSeenAt)
             .HasColumnName("last_seen_at");
@@ -112,5 +116,8 @@ public class DeviceConfiguration : IEntityTypeConfiguration<Device>
 
         // Ignore domain events collection (not persisted)
         builder.Ignore("DomainEvents");
+
+        // Computed convenience property, not a column
+        builder.Ignore(d => d.IsKeyClaimAvailable);
     }
 }

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Configurations/DeviceRegistrationTokenConfiguration.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Configurations/DeviceRegistrationTokenConfiguration.cs
@@ -56,6 +56,11 @@ public class DeviceRegistrationTokenConfiguration : IEntityTypeConfiguration<Dev
         builder.Property(t => t.MaxUses)
             .HasColumnName("max_uses");
 
+        builder.Property(t => t.AutoApprove)
+            .HasColumnName("auto_approve")
+            .HasDefaultValue(false)
+            .IsRequired();
+
         builder.Property(t => t.CurrentUses)
             .HasColumnName("current_uses")
             .IsRequired();

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Migrations/20260613205240_AddDeviceKeyClaimedAt.Designer.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Migrations/20260613205240_AddDeviceKeyClaimedAt.Designer.cs
@@ -2,18 +2,21 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SignalBeam.DeviceManager.Infrastructure.Persistence;
 
 #nullable disable
 
-namespace SignalBeam.DeviceManager.Infrastructure.Migrations
+namespace SignalBeam.DeviceManager.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DeviceDbContext))]
-    partial class DeviceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613205240_AddDeviceKeyClaimedAt")]
+    partial class AddDeviceKeyClaimedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Migrations/20260613205240_AddDeviceKeyClaimedAt.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Migrations/20260613205240_AddDeviceKeyClaimedAt.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SignalBeam.DeviceManager.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceKeyClaimedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "key_claimed_at",
+                schema: "device_manager",
+                table: "devices",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "key_claimed_at",
+                schema: "device_manager",
+                table: "devices");
+        }
+    }
+}

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Migrations/20260613211617_AddRegistrationTokenAutoApprove.Designer.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Migrations/20260613211617_AddRegistrationTokenAutoApprove.Designer.cs
@@ -2,18 +2,21 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SignalBeam.DeviceManager.Infrastructure.Persistence;
 
 #nullable disable
 
-namespace SignalBeam.DeviceManager.Infrastructure.Migrations
+namespace SignalBeam.DeviceManager.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DeviceDbContext))]
-    partial class DeviceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613211617_AddRegistrationTokenAutoApprove")]
+    partial class AddRegistrationTokenAutoApprove
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Migrations/20260613211617_AddRegistrationTokenAutoApprove.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Persistence/Migrations/20260613211617_AddRegistrationTokenAutoApprove.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SignalBeam.DeviceManager.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRegistrationTokenAutoApprove : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "auto_approve",
+                schema: "device_manager",
+                table: "device_registration_tokens",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "auto_approve",
+                schema: "device_manager",
+                table: "device_registration_tokens");
+        }
+    }
+}

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/CheckRegistrationStatusCommand.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/CheckRegistrationStatusCommand.cs
@@ -83,6 +83,10 @@ public class CheckRegistrationStatusCommandHandler
                     apiKey = claimed.ApiKey;
                     apiKeyExpiresAt = claimed.ExpiresAt;
 
+                    // The registration token has served its purpose; don't keep it on disk
+                    // alongside the API key (least persistence of credentials).
+                    credentials.RegistrationToken = null;
+
                     _logger.LogInformation(
                         "Claimed API key for device {DeviceId}",
                         credentials.DeviceId);

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/CheckRegistrationStatusCommand.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/CheckRegistrationStatusCommand.cs
@@ -64,13 +64,45 @@ public class CheckRegistrationStatusCommandHandler
             // Fetch current registration status from cloud
             var status = await _cloudClient.CheckRegistrationStatusAsync(credentials.DeviceId, cancellationToken);
 
-            // Update stored credentials if status changed
-            if (status.Status != credentials.RegistrationStatus ||
-                (status.ApiKey != null && status.ApiKey != credentials.ApiKey))
+            var apiKey = credentials.ApiKey ?? status.ApiKey;
+            var apiKeyExpiresAt = credentials.ApiKeyExpiresAt ?? status.ApiKeyExpiresAt;
+
+            // Once approved, claim the API key exactly once using the retained registration token.
+            if (status.Status == "Approved" &&
+                apiKey == null &&
+                status.KeyClaimAvailable &&
+                !string.IsNullOrEmpty(credentials.RegistrationToken))
+            {
+                try
+                {
+                    var claimed = await _cloudClient.ClaimApiKeyAsync(
+                        credentials.DeviceId,
+                        credentials.RegistrationToken!,
+                        cancellationToken);
+
+                    apiKey = claimed.ApiKey;
+                    apiKeyExpiresAt = claimed.ExpiresAt;
+
+                    _logger.LogInformation(
+                        "Claimed API key for device {DeviceId}",
+                        credentials.DeviceId);
+                }
+                catch (Exception ex)
+                {
+                    // Transient failures shouldn't abort the poll — the next cycle retries.
+                    _logger.LogWarning(
+                        ex,
+                        "Failed to claim API key for device {DeviceId}; will retry on next poll",
+                        credentials.DeviceId);
+                }
+            }
+
+            // Persist any change to status or the newly claimed key.
+            if (status.Status != credentials.RegistrationStatus || apiKey != credentials.ApiKey)
             {
                 credentials.RegistrationStatus = status.Status;
-                credentials.ApiKey = status.ApiKey;
-                credentials.ApiKeyExpiresAt = status.ApiKeyExpiresAt;
+                credentials.ApiKey = apiKey;
+                credentials.ApiKeyExpiresAt = apiKeyExpiresAt;
 
                 await _credentialsStore.SaveCredentialsAsync(credentials, cancellationToken);
 
@@ -78,15 +110,15 @@ public class CheckRegistrationStatusCommandHandler
                     "Device {DeviceId} registration status updated to {Status}. API key: {HasApiKey}",
                     credentials.DeviceId,
                     status.Status,
-                    status.ApiKey != null ? "Received" : "Not yet provided");
+                    apiKey != null ? "Received" : "Not yet provided");
             }
 
             return Result<CheckRegistrationStatusResponse>.Success(
                 new CheckRegistrationStatusResponse(
                     status.Status,
                     status.Status == "Approved",
-                    status.ApiKey,
-                    status.ApiKeyExpiresAt));
+                    apiKey,
+                    apiKeyExpiresAt));
         }
         catch (Exception ex)
         {

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/RegisterDeviceCommand.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/RegisterDeviceCommand.cs
@@ -71,7 +71,9 @@ public class RegisterDeviceCommandHandler
                 RegistrationStatus = response.Status,
                 RegisteredAt = response.RegisteredAt,
                 ApiKey = response.ApiKey,
-                ApiKeyExpiresAt = response.ApiKeyExpiresAt
+                ApiKeyExpiresAt = response.ApiKeyExpiresAt,
+                // Retained so the agent can claim its API key once approved.
+                RegistrationToken = command.RegistrationToken
             };
 
             await _credentialsStore.SaveCredentialsAsync(credentials, cancellationToken);

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/RequestCertificateCommand.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/RequestCertificateCommand.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Logging;
+using SignalBeam.EdgeAgent.Application.Services;
+using SignalBeam.Shared.Infrastructure.Results;
+
+namespace SignalBeam.EdgeAgent.Application.Commands;
+
+/// <summary>
+/// Provisions an mTLS client certificate: generates a key pair and CSR locally, has the cloud CA
+/// sign it, stores the certificate material, and records it in the device credentials. The private
+/// key never leaves the device.
+/// </summary>
+public record RequestCertificateCommand;
+
+public record RequestCertificateResponse(
+    string SerialNumber,
+    DateTimeOffset ExpiresAt,
+    string CertificatePath);
+
+public class RequestCertificateCommandHandler
+{
+    private readonly ICloudClient _cloudClient;
+    private readonly ICsrGenerator _csrGenerator;
+    private readonly ICertificateStore _certificateStore;
+    private readonly IDeviceCredentialsStore _credentialsStore;
+    private readonly ILogger<RequestCertificateCommandHandler> _logger;
+
+    public RequestCertificateCommandHandler(
+        ICloudClient cloudClient,
+        ICsrGenerator csrGenerator,
+        ICertificateStore certificateStore,
+        IDeviceCredentialsStore credentialsStore,
+        ILogger<RequestCertificateCommandHandler> logger)
+    {
+        _cloudClient = cloudClient;
+        _csrGenerator = csrGenerator;
+        _certificateStore = certificateStore;
+        _credentialsStore = credentialsStore;
+        _logger = logger;
+    }
+
+    public async Task<Result<RequestCertificateResponse>> Handle(
+        RequestCertificateCommand command,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var credentials = await _credentialsStore.LoadCredentialsAsync(cancellationToken);
+            if (credentials is null)
+            {
+                return Result.Failure<RequestCertificateResponse>(
+                    Error.Validation("NotRegistered", "Device is not registered. Please register first."));
+            }
+
+            // The CSR request is authenticated by the device API key, so a key must exist.
+            if (string.IsNullOrEmpty(credentials.ApiKey))
+            {
+                return Result.Failure<RequestCertificateResponse>(
+                    Error.Validation("NoApiKey", "Device has no API key yet; cannot request a certificate."));
+            }
+
+            var subject = $"CN=device-{credentials.DeviceId}, O=SignalBeam";
+            var (csrPem, privateKeyPem) = _csrGenerator.GenerateCsr(subject);
+
+            var bundle = await _cloudClient.RequestCertificateAsync(credentials.DeviceId, csrPem, cancellationToken);
+
+            var paths = await _certificateStore.SaveAsync(
+                bundle.CertificatePem,
+                privateKeyPem,
+                bundle.CaCertificatePem,
+                cancellationToken);
+
+            credentials.ClientCertificatePath = paths.CertificatePath;
+            credentials.ClientPrivateKeyPath = paths.PrivateKeyPath;
+            credentials.CaCertificatePath = paths.CaCertificatePath;
+            credentials.CertificateSerialNumber = bundle.SerialNumber;
+            credentials.CertificateExpiresAt = bundle.ExpiresAt;
+
+            await _credentialsStore.SaveCredentialsAsync(credentials, cancellationToken);
+
+            _logger.LogInformation(
+                "Provisioned mTLS certificate for device {DeviceId}; serial {Serial}, expires {Expiry:O}",
+                credentials.DeviceId, bundle.SerialNumber, bundle.ExpiresAt);
+
+            return Result<RequestCertificateResponse>.Success(
+                new RequestCertificateResponse(bundle.SerialNumber, bundle.ExpiresAt, paths.CertificatePath));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to provision certificate");
+            return Result.Failure<RequestCertificateResponse>(
+                Error.Failure("RequestCertificate.Failed", $"Failed to provision certificate: {ex.Message}"));
+        }
+    }
+}

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/SendHeartbeatCommand.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Commands/SendHeartbeatCommand.cs
@@ -10,17 +10,20 @@ public class SendHeartbeatCommandHandler
 {
     private readonly ICloudClient _cloudClient;
     private readonly IHeartbeatPublisher _heartbeatPublisher;
+    private readonly IMetricsPublisher _metricsPublisher;
     private readonly IMetricsCollector _metricsCollector;
     private readonly ILogger<SendHeartbeatCommandHandler> _logger;
 
     public SendHeartbeatCommandHandler(
         ICloudClient cloudClient,
         IHeartbeatPublisher heartbeatPublisher,
+        IMetricsPublisher metricsPublisher,
         IMetricsCollector metricsCollector,
         ILogger<SendHeartbeatCommandHandler> logger)
     {
         _cloudClient = cloudClient;
         _heartbeatPublisher = heartbeatPublisher;
+        _metricsPublisher = metricsPublisher;
         _metricsCollector = metricsCollector;
         _logger = logger;
     }
@@ -38,7 +41,12 @@ public class SendHeartbeatCommandHandler
                 DateTime.UtcNow,
                 metrics);
 
-            // Dual-publish: try NATS first, fall back to HTTP
+            // Publish host metrics to the telemetry pipeline (JetStream). Best-effort:
+            // a NATS outage must not fail the heartbeat — the metrics also ride on the
+            // HTTP heartbeat below, which DeviceManager persists for the device status view.
+            await TryPublishMetricsViaNatsAsync(command.DeviceId, metrics, cancellationToken);
+
+            // Dual-publish heartbeat status: try NATS first, fall back to HTTP
             var natsSucceeded = await TryPublishViaNatsAsync(command.DeviceId, cancellationToken);
 
             if (!natsSucceeded)
@@ -57,6 +65,28 @@ public class SendHeartbeatCommandHandler
         {
             return Result.Failure(
                 Error.Failure("Heartbeat.Failed", $"Failed to send heartbeat: {ex.Message}"));
+        }
+    }
+
+    private async Task TryPublishMetricsViaNatsAsync(
+        Guid deviceId,
+        DeviceMetrics metrics,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _metricsPublisher.PublishMetricsAsync(
+                deviceId,
+                metrics,
+                metrics.RunningContainers,
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to publish metrics via NATS for device {DeviceId}",
+                deviceId);
         }
     }
 

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Models/DeviceCredentials.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Models/DeviceCredentials.cs
@@ -31,6 +31,12 @@ public class DeviceCredentials
     public string RegistrationStatus { get; set; } = "Pending";
 
     /// <summary>
+    /// The registration token this device registered with, retained so the agent can
+    /// claim its API key once after approval. Stored in the 0600 credentials file.
+    /// </summary>
+    public string? RegistrationToken { get; set; }
+
+    /// <summary>
     /// When the device was registered.
     /// </summary>
     public DateTimeOffset RegisteredAt { get; set; }

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICertificateStore.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICertificateStore.cs
@@ -1,0 +1,22 @@
+namespace SignalBeam.EdgeAgent.Application.Services;
+
+/// <summary>
+/// Persists the device's mTLS certificate material to local storage.
+/// </summary>
+public interface ICertificateStore
+{
+    /// <summary>
+    /// Writes the certificate, private key, and CA certificate to disk (the private key with
+    /// restrictive permissions) and returns the resulting file paths.
+    /// </summary>
+    Task<StoredCertificatePaths> SaveAsync(
+        string certificatePem,
+        string privateKeyPem,
+        string caCertificatePem,
+        CancellationToken cancellationToken = default);
+}
+
+public record StoredCertificatePaths(
+    string CertificatePath,
+    string PrivateKeyPath,
+    string CaCertificatePath);

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICloudClient.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICloudClient.cs
@@ -56,7 +56,12 @@ public record DeviceMetrics(
     double CpuUsagePercent,
     double MemoryUsagePercent,
     double DiskUsagePercent,
-    long UptimeSeconds);
+    long UptimeSeconds,
+    int RunningContainers = 0,
+    long MemoryTotalBytes = 0,
+    long MemoryUsedBytes = 0,
+    long DiskTotalBytes = 0,
+    long DiskUsedBytes = 0);
 
 public record DesiredState(
     string? BundleId,

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICloudClient.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICloudClient.cs
@@ -18,6 +18,13 @@ public interface ICloudClient
         string registrationToken,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Rotates the device API key, authenticated by the device's current (still-valid) key.
+    /// </summary>
+    Task<ClaimedApiKey> RotateApiKeyAsync(
+        Guid deviceId,
+        CancellationToken cancellationToken = default);
+
     Task SendHeartbeatAsync(
         DeviceHeartbeat heartbeat,
         CancellationToken cancellationToken = default);

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICloudClient.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICloudClient.cs
@@ -25,6 +25,14 @@ public interface ICloudClient
         Guid deviceId,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Submits a device-generated CSR to the cloud CA and returns the signed certificate bundle.
+    /// </summary>
+    Task<DeviceCertificateBundle> RequestCertificateAsync(
+        Guid deviceId,
+        string csrPem,
+        CancellationToken cancellationToken = default);
+
     Task SendHeartbeatAsync(
         DeviceHeartbeat heartbeat,
         CancellationToken cancellationToken = default);
@@ -66,6 +74,12 @@ public record RegistrationStatusResponse(
 public record ClaimedApiKey(
     string ApiKey,
     DateTimeOffset? ExpiresAt);
+
+public record DeviceCertificateBundle(
+    string CertificatePem,
+    string CaCertificatePem,
+    string SerialNumber,
+    DateTimeOffset ExpiresAt);
 
 public record DeviceHeartbeat(
     Guid DeviceId,

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICloudClient.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICloudClient.cs
@@ -10,6 +10,14 @@ public interface ICloudClient
         Guid deviceId,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Claims the device API key once, after approval, authenticated by the registration token.
+    /// </summary>
+    Task<ClaimedApiKey> ClaimApiKeyAsync(
+        Guid deviceId,
+        string registrationToken,
+        CancellationToken cancellationToken = default);
+
     Task SendHeartbeatAsync(
         DeviceHeartbeat heartbeat,
         CancellationToken cancellationToken = default);
@@ -45,7 +53,12 @@ public record DeviceRegistrationResponse(
 public record RegistrationStatusResponse(
     string Status,
     string? ApiKey = null,
-    DateTimeOffset? ApiKeyExpiresAt = null);
+    DateTimeOffset? ApiKeyExpiresAt = null,
+    bool KeyClaimAvailable = false);
+
+public record ClaimedApiKey(
+    string ApiKey,
+    DateTimeOffset? ExpiresAt);
 
 public record DeviceHeartbeat(
     Guid DeviceId,

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICsrGenerator.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/ICsrGenerator.cs
@@ -1,0 +1,14 @@
+namespace SignalBeam.EdgeAgent.Application.Services;
+
+/// <summary>
+/// Generates a key pair and a PKCS#10 certificate signing request (CSR) on the device,
+/// so the private key never leaves the device when provisioning an mTLS certificate.
+/// </summary>
+public interface ICsrGenerator
+{
+    /// <summary>
+    /// Generates a fresh RSA key pair and a CSR for the given subject.
+    /// </summary>
+    /// <returns>The CSR and the matching private key, both PEM-encoded.</returns>
+    (string CsrPem, string PrivateKeyPem) GenerateCsr(string subject);
+}

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/IKeyRotationService.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/Services/IKeyRotationService.cs
@@ -1,0 +1,14 @@
+namespace SignalBeam.EdgeAgent.Application.Services;
+
+/// <summary>
+/// Detects when the device API key is approaching expiry and rotates it with the cloud,
+/// persisting the new key locally.
+/// </summary>
+public interface IKeyRotationService
+{
+    /// <summary>
+    /// Rotates the API key if it expires within the configured threshold.
+    /// Returns true if a rotation occurred, false if no rotation was needed.
+    /// </summary>
+    Task<bool> CheckAndRotateAsync(CancellationToken cancellationToken = default);
+}

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Commands/RegisterCommand.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Commands/RegisterCommand.cs
@@ -55,11 +55,12 @@ public static class RegisterCommand
 
     private static async Task<int> ExecuteAsync(Guid tenantId, string? deviceId, string token, string cloudUrl)
     {
+        // Point the cloud client at the requested control plane before the provider is built.
+        Environment.SetEnvironmentVariable("Agent__CloudUrl", cloudUrl);
+
         var serviceProvider = HostBuilder.BuildServiceProvider();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
         var logger = loggerFactory.CreateLogger<Program>();
-        var cloudClient = serviceProvider.GetRequiredService<ICloudClient>();
-        var credentialsStore = serviceProvider.GetRequiredService<IDeviceCredentialsStore>();
 
         try
         {
@@ -78,8 +79,7 @@ public static class RegisterCommand
                 hostname,
                 platform);
 
-            var handlerLogger = loggerFactory.CreateLogger<RegisterDeviceCommandHandler>();
-            var handler = new RegisterDeviceCommandHandler(cloudClient, credentialsStore, handlerLogger);
+            var handler = serviceProvider.GetRequiredService<RegisterDeviceCommandHandler>();
             var result = await handler.Handle(command, CancellationToken.None);
 
             if (!result.IsSuccess || result.Value == null)

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Commands/RequestCertCommand.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Commands/RequestCertCommand.cs
@@ -1,0 +1,52 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SignalBeam.EdgeAgent.Application.Commands;
+
+namespace SignalBeam.EdgeAgent.Host.Commands;
+
+/// <summary>
+/// Provisions an mTLS client certificate for this device: generates a key pair and CSR locally,
+/// has the cloud CA sign it, and stores the certificate. The private key never leaves the device.
+/// </summary>
+public static class RequestCertCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("request-cert", "Provision an mTLS client certificate from the cloud CA");
+
+        command.SetHandler(async () => await ExecuteAsync());
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync()
+    {
+        var serviceProvider = HostBuilder.BuildServiceProvider();
+        var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<Program>();
+
+        try
+        {
+            var handler = serviceProvider.GetRequiredService<RequestCertificateCommandHandler>();
+            var result = await handler.Handle(new RequestCertificateCommand(), CancellationToken.None);
+
+            if (!result.IsSuccess || result.Value is null)
+            {
+                Console.WriteLine($"❌ Certificate provisioning failed: {result.Error?.Message ?? "Unknown error"}");
+                return 1;
+            }
+
+            Console.WriteLine("✅ mTLS certificate provisioned successfully!");
+            Console.WriteLine($"   Serial: {result.Value.SerialNumber}");
+            Console.WriteLine($"   Expires: {result.Value.ExpiresAt:u}");
+            Console.WriteLine($"   Certificate: {result.Value.CertificatePath}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Certificate provisioning failed");
+            Console.WriteLine($"❌ Certificate provisioning failed: {ex.Message}");
+            return 1;
+        }
+    }
+}

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Commands/RunCommand.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Commands/RunCommand.cs
@@ -2,7 +2,9 @@ using System.CommandLine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using SignalBeam.EdgeAgent.Application.Services;
+using SignalBeam.EdgeAgent.Host.Configuration;
 using SignalBeam.EdgeAgent.Host.Services;
 
 namespace SignalBeam.EdgeAgent.Host.Commands;
@@ -27,34 +29,16 @@ public static class RunCommand
         {
             var host = HostBuilder.BuildHost();
 
-            // Check if device is registered
             var stateManager = host.Services.GetRequiredService<DeviceStateManager>();
-            if (!stateManager.IsRegistered)
-            {
-                Console.WriteLine("❌ Device is not registered. Please run 'signalbeam-agent register' first.");
-                return 1;
-            }
-
             var logger = host.Services.GetRequiredService<ILogger<Program>>();
-            logger.LogInformation("Starting SignalBeam Edge Agent");
-            logger.LogInformation("Device ID: {DeviceId}", stateManager.DeviceId);
 
-            // Check credentials and registration status
+            // Credentials are the source of truth for registration state.
             var credentialsStore = host.Services.GetRequiredService<IDeviceCredentialsStore>();
             var credentials = await credentialsStore.LoadCredentialsAsync(CancellationToken.None);
 
             if (credentials == null)
             {
                 Console.WriteLine("❌ Device credentials not found. Please run 'signalbeam-agent register' first.");
-                return 1;
-            }
-
-            // Check registration status
-            if (credentials.RegistrationStatus == "Pending")
-            {
-                Console.WriteLine("⏳ Device registration is pending approval.");
-                Console.WriteLine("   The agent cannot start until an administrator approves the device.");
-                Console.WriteLine("   Check status with: signalbeam-agent status");
                 return 1;
             }
 
@@ -65,17 +49,10 @@ public static class RunCommand
                 return 1;
             }
 
-            // Check API key
-            if (string.IsNullOrEmpty(credentials.ApiKey))
-            {
-                Console.WriteLine("❌ Device API key not found.");
-                Console.WriteLine("   Registration may still be pending approval.");
-                Console.WriteLine("   Check status with: signalbeam-agent status");
-                return 1;
-            }
+            var hasApiKey = !string.IsNullOrEmpty(credentials.ApiKey);
 
-            // Check API key expiration
-            if (credentials.ApiKeyExpiresAt.HasValue)
+            // A claimed key that has already expired can't be used and can't be rotated.
+            if (hasApiKey && credentials.ApiKeyExpiresAt.HasValue)
             {
                 var daysUntilExpiration = (credentials.ApiKeyExpiresAt.Value - DateTimeOffset.UtcNow).TotalDays;
 
@@ -89,15 +66,33 @@ public static class RunCommand
                 if (daysUntilExpiration < 7)
                 {
                     Console.WriteLine($"⚠️  Warning: API key expires in {daysUntilExpiration:F1} days.");
-                    Console.WriteLine("   Consider rotating the key soon.");
+                    Console.WriteLine("   The agent will attempt to rotate it automatically.");
                     Console.WriteLine();
                 }
             }
 
+            logger.LogInformation("Starting SignalBeam Edge Agent");
+            logger.LogInformation("Device ID: {DeviceId}", credentials.DeviceId);
+
+            // Promote to registered so the heartbeat & reconciliation loops start. When the key
+            // hasn't been claimed yet, RegistrationPollingService does this once approval lands.
+            if (hasApiKey)
+            {
+                var options = host.Services.GetRequiredService<IOptions<AgentOptions>>().Value;
+                stateManager.SetRegistrationState(credentials.DeviceId, credentials.ApiKey!, options.CloudUrl);
+            }
+
             Console.WriteLine("🚀 SignalBeam Edge Agent starting...");
-            Console.WriteLine($"   Device ID: {stateManager.DeviceId}");
-            Console.WriteLine($"   Cloud Endpoint: {stateManager.CloudEndpoint}");
+            Console.WriteLine($"   Device ID: {credentials.DeviceId}");
             Console.WriteLine($"   Registration Status: {credentials.RegistrationStatus}");
+
+            if (!hasApiKey)
+            {
+                Console.WriteLine();
+                Console.WriteLine("⏳ Registration is pending approval. The agent will poll and start the");
+                Console.WriteLine("   heartbeat automatically once approved and its API key is claimed.");
+            }
+
             Console.WriteLine();
             Console.WriteLine("Press Ctrl+C to stop the agent");
             Console.WriteLine();

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Configuration/AgentOptions.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Configuration/AgentOptions.cs
@@ -11,6 +11,16 @@ public class AgentOptions
     /// How often (seconds) the agent polls for registration approval while still pending.
     /// </summary>
     public int RegistrationPollIntervalSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Rotate the API key when it expires within this many days.
+    /// </summary>
+    public int KeyRotationThresholdDays { get; set; } = 7;
+
+    /// <summary>
+    /// How often (hours) the key lifecycle service checks for an expiring API key.
+    /// </summary>
+    public double KeyLifecycleCheckIntervalHours { get; set; } = 24.0;
     public int ReconciliationIntervalSeconds { get; set; } = 60;
     public int ReconciliationRetryAttempts { get; set; } = 3;
     public int ReconciliationRetryDelaySeconds { get; set; } = 10;

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Configuration/AgentOptions.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Configuration/AgentOptions.cs
@@ -6,6 +6,11 @@ public class AgentOptions
 
     public string CloudUrl { get; set; } = "https://api.signalbeam.com";
     public int HeartbeatIntervalSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// How often (seconds) the agent polls for registration approval while still pending.
+    /// </summary>
+    public int RegistrationPollIntervalSeconds { get; set; } = 300;
     public int ReconciliationIntervalSeconds { get; set; } = 60;
     public int ReconciliationRetryAttempts { get; set; } = 3;
     public int ReconciliationRetryDelaySeconds { get; set; } = 10;

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Configuration/AgentOptions.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Configuration/AgentOptions.cs
@@ -12,4 +12,10 @@ public class AgentOptions
     public int ImagePullTimeoutSeconds { get; set; } = 300;
     public int MaxRetries { get; set; } = 3;
     public string LogFilePath { get; set; } = "/var/log/signalbeam-agent/agent.log";
+
+    /// <summary>
+    /// Filesystem mount point whose usage is reported as the device disk metric.
+    /// Defaults to the root filesystem; override for devices with a dedicated data partition.
+    /// </summary>
+    public string MonitoredDiskPath { get; set; } = "/";
 }

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/HostBuilder.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/HostBuilder.cs
@@ -45,6 +45,7 @@ public static class HostBuilder
 
                 // Background services
                 services.AddHostedService<RegistrationPollingService>();
+                services.AddHostedService<KeyLifecycleService>();
                 services.AddHostedService<HeartbeatService>();
                 services.AddHostedService<ReconciliationService>();
                 services.AddHostedService<NatsAssignmentListenerService>();

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/HostBuilder.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/HostBuilder.cs
@@ -42,6 +42,7 @@ public static class HostBuilder
 
                 // Application handlers resolved directly by background services
                 services.AddScoped<CheckRegistrationStatusCommandHandler>();
+                services.AddScoped<RequestCertificateCommandHandler>();
 
                 // Background services
                 services.AddHostedService<RegistrationPollingService>();
@@ -99,6 +100,7 @@ public static class HostBuilder
         // Application handlers used by the CLI commands
         services.AddScoped<RegisterDeviceCommandHandler>();
         services.AddScoped<CheckRegistrationStatusCommandHandler>();
+        services.AddScoped<RequestCertificateCommandHandler>();
 
         return services.BuildServiceProvider();
     }

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/HostBuilder.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/HostBuilder.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using SignalBeam.EdgeAgent.Application.Commands;
 using SignalBeam.EdgeAgent.Host.Configuration;
 using SignalBeam.EdgeAgent.Host.Services;
 using SignalBeam.EdgeAgent.Infrastructure;
@@ -39,7 +40,11 @@ public static class HostBuilder
                 // Infrastructure
                 services.AddInfrastructure(context.Configuration);
 
+                // Application handlers resolved directly by background services
+                services.AddScoped<CheckRegistrationStatusCommandHandler>();
+
                 // Background services
+                services.AddHostedService<RegistrationPollingService>();
                 services.AddHostedService<HeartbeatService>();
                 services.AddHostedService<ReconciliationService>();
                 services.AddHostedService<NatsAssignmentListenerService>();
@@ -89,6 +94,10 @@ public static class HostBuilder
 
         // Infrastructure
         services.AddInfrastructure(configuration);
+
+        // Application handlers used by the CLI commands
+        services.AddScoped<RegisterDeviceCommandHandler>();
+        services.AddScoped<CheckRegistrationStatusCommandHandler>();
 
         return services.BuildServiceProvider();
     }

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Program.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Program.cs
@@ -12,6 +12,7 @@ public class Program
         // Add all commands
         rootCommand.AddCommand(RegisterCommand.Create());
         rootCommand.AddCommand(RunCommand.Create());
+        rootCommand.AddCommand(RequestCertCommand.Create());
         rootCommand.AddCommand(StatusCommand.Create());
         rootCommand.AddCommand(VersionCommand.Create());
         rootCommand.AddCommand(LogsCommand.Create());

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Services/KeyLifecycleService.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Services/KeyLifecycleService.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SignalBeam.EdgeAgent.Application.Services;
+using SignalBeam.EdgeAgent.Host.Configuration;
+
+namespace SignalBeam.EdgeAgent.Host.Services;
+
+/// <summary>
+/// Periodically checks the device API key expiry and rotates it before it lapses, so a
+/// long-running device never loses authentication. Waits until the device is registered
+/// (holds a key) before doing any work.
+/// </summary>
+public class KeyLifecycleService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly DeviceStateManager _stateManager;
+    private readonly AgentOptions _options;
+    private readonly ILogger<KeyLifecycleService> _logger;
+
+    public KeyLifecycleService(
+        IServiceScopeFactory scopeFactory,
+        DeviceStateManager stateManager,
+        IOptions<AgentOptions> options,
+        ILogger<KeyLifecycleService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _stateManager = stateManager;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = TimeSpan.FromHours(Math.Max(0.1, _options.KeyLifecycleCheckIntervalHours));
+        _logger.LogInformation(
+            "KeyLifecycleService started; checking API key expiry every {Interval}h (threshold {Threshold}d).",
+            interval.TotalHours, _options.KeyRotationThresholdDays);
+
+        // Wait until the device has a key to manage.
+        while (!_stateManager.IsRegistered && !stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var rotationService = scope.ServiceProvider.GetRequiredService<IKeyRotationService>();
+                await rotationService.CheckAndRotateAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during API key lifecycle check");
+            }
+
+            try
+            {
+                await Task.Delay(interval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        _logger.LogInformation("KeyLifecycleService stopped");
+    }
+}

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Services/RegistrationPollingService.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/Services/RegistrationPollingService.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SignalBeam.EdgeAgent.Application.Commands;
+using SignalBeam.EdgeAgent.Application.Models;
+using SignalBeam.EdgeAgent.Application.Services;
+using SignalBeam.EdgeAgent.Host.Configuration;
+
+namespace SignalBeam.EdgeAgent.Host.Services;
+
+/// <summary>
+/// Polls the cloud for registration approval after the device has registered but before it
+/// holds an API key. The status handler claims the key once approval lands; this service then
+/// promotes the device to "registered" so the heartbeat and reconciliation loops can start.
+/// It stops as soon as a key is obtained — or the registration is rejected — so an approved
+/// device incurs no ongoing polling.
+/// </summary>
+public class RegistrationPollingService : BackgroundService
+{
+    private const int MinIntervalSeconds = 5;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IDeviceCredentialsStore _credentialsStore;
+    private readonly DeviceStateManager _stateManager;
+    private readonly AgentOptions _options;
+    private readonly ILogger<RegistrationPollingService> _logger;
+
+    public RegistrationPollingService(
+        IServiceScopeFactory scopeFactory,
+        IDeviceCredentialsStore credentialsStore,
+        DeviceStateManager stateManager,
+        IOptions<AgentOptions> options,
+        ILogger<RegistrationPollingService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _credentialsStore = credentialsStore;
+        _stateManager = stateManager;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var credentials = await _credentialsStore.LoadCredentialsAsync(stoppingToken);
+        if (credentials is null)
+        {
+            _logger.LogDebug("Device is not registered; registration polling is idle.");
+            return;
+        }
+
+        // Already have a key — nothing to poll; just make sure the run loop sees us as registered.
+        if (!string.IsNullOrEmpty(credentials.ApiKey))
+        {
+            PromoteToRegistered(credentials);
+            return;
+        }
+
+        var interval = TimeSpan.FromSeconds(Math.Max(MinIntervalSeconds, _options.RegistrationPollIntervalSeconds));
+        _logger.LogInformation(
+            "Device {DeviceId} awaiting approval; polling for approval every {Interval}s.",
+            credentials.DeviceId, interval.TotalSeconds);
+
+        using var timer = new PeriodicTimer(interval);
+        do
+        {
+            if (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            try
+            {
+                using (var scope = _scopeFactory.CreateScope())
+                {
+                    var handler = scope.ServiceProvider.GetRequiredService<CheckRegistrationStatusCommandHandler>();
+                    await handler.Handle(new CheckRegistrationStatusCommand(), stoppingToken);
+                }
+
+                var updated = await _credentialsStore.LoadCredentialsAsync(stoppingToken);
+
+                if (updated is not null && !string.IsNullOrEmpty(updated.ApiKey))
+                {
+                    PromoteToRegistered(updated);
+                    _logger.LogInformation(
+                        "Device {DeviceId} approved and API key obtained; stopping registration polling.",
+                        updated.DeviceId);
+                    return;
+                }
+
+                if (updated is not null &&
+                    string.Equals(updated.RegistrationStatus, "Rejected", StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError(
+                        "Device {DeviceId} registration was rejected; stopping registration polling.",
+                        updated.DeviceId);
+                    return;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Registration poll failed; will retry on next cycle.");
+            }
+        }
+        while (await WaitForNextTickAsync(timer, stoppingToken));
+    }
+
+    private static async Task<bool> WaitForNextTickAsync(PeriodicTimer timer, CancellationToken token)
+    {
+        try
+        {
+            return await timer.WaitForNextTickAsync(token);
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    private void PromoteToRegistered(DeviceCredentials credentials)
+    {
+        if (_stateManager.IsRegistered)
+        {
+            return;
+        }
+
+        _stateManager.SetRegistrationState(
+            credentials.DeviceId,
+            credentials.ApiKey!,
+            _options.CloudUrl);
+    }
+}

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Cloud/HttpCloudClient.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Cloud/HttpCloudClient.cs
@@ -140,6 +140,41 @@ public class HttpCloudClient : ICloudClient
         }
     }
 
+    public async Task<DeviceCertificateBundle> RequestCertificateAsync(
+        Guid deviceId,
+        string csrPem,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("Requesting certificate for device {DeviceId}", deviceId);
+
+            // Authenticated by the device API key, added by DeviceApiKeyHandler.
+            var response = await _httpClient.PostAsJsonAsync(
+                $"/api/certificates/{deviceId}/sign-csr",
+                new { csr = csrPem },
+                cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<DeviceCertificateBundle>(cancellationToken);
+
+            if (result is null || string.IsNullOrEmpty(result.CertificatePem))
+            {
+                throw new InvalidOperationException("sign-csr response did not contain a certificate");
+            }
+
+            _logger.LogInformation("Certificate issued for device {DeviceId}, serial {Serial}",
+                deviceId, result.SerialNumber);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to request certificate for device {DeviceId}", deviceId);
+            throw;
+        }
+    }
+
     public async Task SendHeartbeatAsync(
         DeviceHeartbeat heartbeat,
         CancellationToken cancellationToken = default)

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Cloud/HttpCloudClient.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Cloud/HttpCloudClient.cs
@@ -107,6 +107,39 @@ public class HttpCloudClient : ICloudClient
         }
     }
 
+    public async Task<ClaimedApiKey> RotateApiKeyAsync(
+        Guid deviceId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("Rotating API key for device {DeviceId}", deviceId);
+
+            // Authenticated by the current device API key, added by DeviceApiKeyHandler.
+            var response = await _httpClient.PostAsync(
+                $"/api/devices/{deviceId}/rotate-key",
+                content: null,
+                cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<ClaimedApiKey>(cancellationToken);
+
+            if (result is null || string.IsNullOrEmpty(result.ApiKey))
+            {
+                throw new InvalidOperationException("Rotate-key response did not contain an API key");
+            }
+
+            _logger.LogInformation("API key rotated successfully for device {DeviceId}", deviceId);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to rotate API key for device {DeviceId}", deviceId);
+            throw;
+        }
+    }
+
     public async Task SendHeartbeatAsync(
         DeviceHeartbeat heartbeat,
         CancellationToken cancellationToken = default)

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Cloud/HttpCloudClient.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Cloud/HttpCloudClient.cs
@@ -74,6 +74,39 @@ public class HttpCloudClient : ICloudClient
         }
     }
 
+    public async Task<ClaimedApiKey> ClaimApiKeyAsync(
+        Guid deviceId,
+        string registrationToken,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("Claiming API key for device {DeviceId}", deviceId);
+
+            var response = await _httpClient.PostAsJsonAsync(
+                $"/api/devices/{deviceId}/claim-key",
+                new { registrationToken },
+                cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<ClaimedApiKey>(cancellationToken);
+
+            if (result is null || string.IsNullOrEmpty(result.ApiKey))
+            {
+                throw new InvalidOperationException("Claim-key response did not contain an API key");
+            }
+
+            _logger.LogInformation("API key claimed successfully for device {DeviceId}", deviceId);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to claim API key for device {DeviceId}", deviceId);
+            throw;
+        }
+    }
+
     public async Task SendHeartbeatAsync(
         DeviceHeartbeat heartbeat,
         CancellationToken cancellationToken = default)

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Cloud/KeyRotationService.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Cloud/KeyRotationService.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Logging;
+using SignalBeam.EdgeAgent.Application.Services;
+
+namespace SignalBeam.EdgeAgent.Infrastructure.Cloud;
+
+/// <summary>
+/// Rotates the device API key before it expires. The agent must rotate while its current key
+/// is still valid (rotation is authenticated by that key); once expired, rotation is no longer
+/// possible and the device must be re-provisioned.
+/// </summary>
+public sealed class KeyRotationService : IKeyRotationService
+{
+    private readonly ICloudClient _cloudClient;
+    private readonly IDeviceCredentialsStore _credentialsStore;
+    private readonly ILogger<KeyRotationService> _logger;
+    private readonly int _rotationThresholdDays;
+
+    public KeyRotationService(
+        ICloudClient cloudClient,
+        IDeviceCredentialsStore credentialsStore,
+        ILogger<KeyRotationService> logger,
+        int rotationThresholdDays)
+    {
+        _cloudClient = cloudClient;
+        _credentialsStore = credentialsStore;
+        _logger = logger;
+        _rotationThresholdDays = rotationThresholdDays;
+    }
+
+    public async Task<bool> CheckAndRotateAsync(CancellationToken cancellationToken = default)
+    {
+        var credentials = await _credentialsStore.LoadCredentialsAsync(cancellationToken);
+        if (credentials is null || string.IsNullOrEmpty(credentials.ApiKey))
+        {
+            return false;
+        }
+
+        // A key with no expiry never needs rotation.
+        if (!credentials.ApiKeyExpiresAt.HasValue)
+        {
+            return false;
+        }
+
+        var daysUntilExpiry = (credentials.ApiKeyExpiresAt.Value - DateTimeOffset.UtcNow).TotalDays;
+        if (daysUntilExpiry > _rotationThresholdDays)
+        {
+            return false;
+        }
+
+        if (daysUntilExpiry <= 0)
+        {
+            // Already expired — rotation can't authenticate; surface for operator intervention.
+            _logger.LogError(
+                "Device {DeviceId} API key has expired; automatic rotation is no longer possible.",
+                credentials.DeviceId);
+            return false;
+        }
+
+        _logger.LogInformation(
+            "Device {DeviceId} API key expires in {Days:F1} days; rotating.",
+            credentials.DeviceId, daysUntilExpiry);
+
+        var rotated = await _cloudClient.RotateApiKeyAsync(credentials.DeviceId, cancellationToken);
+
+        credentials.ApiKey = rotated.ApiKey;
+        credentials.ApiKeyExpiresAt = rotated.ExpiresAt;
+        await _credentialsStore.SaveCredentialsAsync(credentials, cancellationToken);
+
+        _logger.LogInformation(
+            "Device {DeviceId} API key rotated; new expiry {Expiry:O}.",
+            credentials.DeviceId, rotated.ExpiresAt);
+
+        return true;
+    }
+}

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/DependencyInjection.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/DependencyInjection.cs
@@ -23,8 +23,16 @@ public static class DependencyInjection
         // Register Docker container manager
         services.AddSingleton<IContainerManager, DockerContainerManager>();
 
-        // Register metrics collector
-        services.AddSingleton<IMetricsCollector, SystemMetricsCollector>();
+        // Register metrics collector — reads host-level metrics from /proc on Linux and the
+        // running container count from Docker. Disk mount point is configurable (default "/").
+        services.AddSingleton<IMetricsCollector>(sp =>
+        {
+            var monitoredDiskPath = configuration["Agent:MonitoredDiskPath"] ?? "/";
+            return new SystemMetricsCollector(
+                sp.GetRequiredService<ILogger<SystemMetricsCollector>>(),
+                sp.GetRequiredService<IContainerManager>(),
+                monitoredDiskPath);
+        });
 
         // Register device credentials store
         services.AddSingleton<IDeviceCredentialsStore, FileDeviceCredentialsStore>();

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/DependencyInjection.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/DependencyInjection.cs
@@ -37,6 +37,13 @@ public static class DependencyInjection
         // Register device credentials store
         services.AddSingleton<IDeviceCredentialsStore, FileDeviceCredentialsStore>();
 
+        // Key rotation service — rotation threshold configurable (default 7 days)
+        services.AddScoped<IKeyRotationService>(sp => new KeyRotationService(
+            sp.GetRequiredService<ICloudClient>(),
+            sp.GetRequiredService<IDeviceCredentialsStore>(),
+            sp.GetRequiredService<ILogger<KeyRotationService>>(),
+            int.TryParse(configuration["Agent:KeyRotationThresholdDays"], out var threshold) ? threshold : 7));
+
         // Register API key handler
         services.AddTransient<DeviceApiKeyHandler>();
 

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/DependencyInjection.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/DependencyInjection.cs
@@ -9,6 +9,7 @@ using SignalBeam.EdgeAgent.Infrastructure.Cloud;
 using SignalBeam.EdgeAgent.Infrastructure.Container;
 using SignalBeam.EdgeAgent.Infrastructure.Messaging;
 using SignalBeam.EdgeAgent.Infrastructure.Metrics;
+using SignalBeam.EdgeAgent.Infrastructure.Security;
 using SignalBeam.EdgeAgent.Infrastructure.Storage;
 using SignalBeam.Shared.Infrastructure.Messaging;
 
@@ -36,6 +37,18 @@ public static class DependencyInjection
 
         // Register device credentials store
         services.AddSingleton<IDeviceCredentialsStore, FileDeviceCredentialsStore>();
+
+        // mTLS certificate provisioning: device-side CSR generation + file storage
+        services.AddSingleton<ICsrGenerator, CsrGenerator>();
+        services.AddSingleton<ICertificateStore>(_ =>
+        {
+            var certDir = configuration["Agent:CertificateDirectory"]
+                ?? Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "signalbeam-agent",
+                    "certs");
+            return new FileCertificateStore(certDir);
+        });
 
         // Key rotation service — rotation threshold configurable (default 7 days)
         services.AddScoped<IKeyRotationService>(sp => new KeyRotationService(

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Messaging/NatsMetricsPublisher.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Messaging/NatsMetricsPublisher.cs
@@ -31,6 +31,10 @@ public sealed class NatsMetricsPublisher : IMetricsPublisher
     {
         var subject = $"signalbeam.telemetry.metrics.{deviceId}";
 
+        // Raw byte counters aren't first-class fields on the wire schema; carry them in
+        // AdditionalMetrics so the telemetry pipeline can surface absolute memory/disk usage.
+        var additionalMetrics = BuildAdditionalMetrics(metrics);
+
         var message = new DeviceMetricsMessage(
             DeviceId: deviceId,
             Timestamp: DateTimeOffset.UtcNow,
@@ -38,7 +42,8 @@ public sealed class NatsMetricsPublisher : IMetricsPublisher
             MemoryUsage: metrics.MemoryUsagePercent,
             DiskUsage: metrics.DiskUsagePercent,
             UptimeSeconds: metrics.UptimeSeconds,
-            RunningContainers: runningContainers);
+            RunningContainers: runningContainers,
+            AdditionalMetrics: additionalMetrics);
 
         _logger.LogDebug(
             "Publishing metrics for device {DeviceId} to {Subject}",
@@ -47,6 +52,31 @@ public sealed class NatsMetricsPublisher : IMetricsPublisher
         var json = JsonSerializer.Serialize(message, _jsonOptions);
         var ack = await _jetStream.PublishAsync(subject, json, cancellationToken: cancellationToken);
         ack.EnsureSuccess();
+    }
+
+    /// <summary>
+    /// Serializes absolute byte counters as a compact JSON object, or returns null when no
+    /// raw values are present (keeps the wire message lean for collectors that don't report them).
+    /// </summary>
+    private string? BuildAdditionalMetrics(DeviceMetrics metrics)
+    {
+        if (metrics.MemoryTotalBytes == 0 &&
+            metrics.MemoryUsedBytes == 0 &&
+            metrics.DiskTotalBytes == 0 &&
+            metrics.DiskUsedBytes == 0)
+        {
+            return null;
+        }
+
+        return JsonSerializer.Serialize(
+            new
+            {
+                memoryTotalBytes = metrics.MemoryTotalBytes,
+                memoryUsedBytes = metrics.MemoryUsedBytes,
+                diskTotalBytes = metrics.DiskTotalBytes,
+                diskUsedBytes = metrics.DiskUsedBytes
+            },
+            _jsonOptions);
     }
 }
 

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Metrics/SystemMetricsCollector.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Metrics/SystemMetricsCollector.cs
@@ -1,163 +1,348 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using SignalBeam.EdgeAgent.Application.Services;
 
 namespace SignalBeam.EdgeAgent.Infrastructure.Metrics;
 
+/// <summary>
+/// Collects host-level system metrics. On Linux (the primary edge target) this reads
+/// <c>/proc/stat</c>, <c>/proc/meminfo</c> and <c>/proc/uptime</c> so CPU, memory and uptime
+/// reflect the whole machine — not just the agent process. On Windows/macOS it degrades to a
+/// best-effort fallback (development only). Collection never throws: a failure in one metric
+/// yields a zero value for that metric so the heartbeat loop is never blocked or crashed.
+/// </summary>
 public class SystemMetricsCollector : IMetricsCollector
 {
-    private readonly ILogger<SystemMetricsCollector> _logger;
-    private readonly DateTime _startTime;
+    internal const string ProcStatPath = "/proc/stat";
+    internal const string ProcMemInfoPath = "/proc/meminfo";
+    internal const string ProcUptimePath = "/proc/uptime";
 
-    public SystemMetricsCollector(ILogger<SystemMetricsCollector> logger)
+    private static readonly TimeSpan CpuSampleDelay = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan ContainerCountTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly ILogger<SystemMetricsCollector> _logger;
+    private readonly IContainerManager _containerManager;
+    private readonly string _monitoredDiskPath;
+    private readonly bool _isLinux;
+
+    public SystemMetricsCollector(
+        ILogger<SystemMetricsCollector> logger,
+        IContainerManager containerManager,
+        string monitoredDiskPath = "/")
     {
         _logger = logger;
-        _startTime = DateTime.UtcNow;
+        _containerManager = containerManager;
+        _monitoredDiskPath = string.IsNullOrWhiteSpace(monitoredDiskPath) ? "/" : monitoredDiskPath;
+        _isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
     }
 
     public async Task<DeviceMetrics> CollectMetricsAsync(CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var cpuUsage = await GetCpuUsageAsync(cancellationToken);
-            var memoryUsage = GetMemoryUsage();
-            var diskUsage = GetDiskUsage();
-            var uptime = GetUptime();
+        var cpuUsage = await GetCpuUsageAsync(cancellationToken);
+        var (memoryPercent, memoryTotal, memoryUsed) = GetMemory();
+        var (diskPercent, diskTotal, diskUsed) = GetDisk();
+        var uptime = GetUptime();
+        var runningContainers = await GetRunningContainerCountAsync(cancellationToken);
 
-            return new DeviceMetrics(
-                cpuUsage,
-                memoryUsage,
-                diskUsage,
-                uptime);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to collect metrics");
-            throw;
-        }
+        return new DeviceMetrics(
+            CpuUsagePercent: cpuUsage,
+            MemoryUsagePercent: memoryPercent,
+            DiskUsagePercent: diskPercent,
+            UptimeSeconds: uptime,
+            RunningContainers: runningContainers,
+            MemoryTotalBytes: memoryTotal,
+            MemoryUsedBytes: memoryUsed,
+            DiskTotalBytes: diskTotal,
+            DiskUsedBytes: diskUsed);
     }
+
+    // ---- CPU --------------------------------------------------------------
 
     private async Task<double> GetCpuUsageAsync(CancellationToken cancellationToken)
     {
-        // Simple CPU usage calculation
-        // For a production system, consider using a more sophisticated approach
+        if (_isLinux && File.Exists(ProcStatPath))
+        {
+            try
+            {
+                var first = ParseProcStatCpu(await File.ReadAllTextAsync(ProcStatPath, cancellationToken));
+                await Task.Delay(CpuSampleDelay, cancellationToken);
+                var second = ParseProcStatCpu(await File.ReadAllTextAsync(ProcStatPath, cancellationToken));
+
+                if (first.HasValue && second.HasValue)
+                {
+                    return ComputeCpuUsagePercent(first.Value, second.Value);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to read system CPU from {Path}; using process fallback", ProcStatPath);
+            }
+        }
+
+        return await GetProcessCpuFallbackAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Degraded cross-platform CPU estimate based on the agent process only.
+    /// Used on Windows/macOS or when <c>/proc/stat</c> is unavailable.
+    /// </summary>
+    private static async Task<double> GetProcessCpuFallbackAsync(CancellationToken cancellationToken)
+    {
         try
         {
             var startTime = DateTime.UtcNow;
-            var startCpuUsage = Process.GetCurrentProcess().TotalProcessorTime;
+            var startCpu = Process.GetCurrentProcess().TotalProcessorTime;
 
-            await Task.Delay(500, cancellationToken);
+            await Task.Delay(CpuSampleDelay, cancellationToken);
 
             var endTime = DateTime.UtcNow;
-            var endCpuUsage = Process.GetCurrentProcess().TotalProcessorTime;
+            var endCpu = Process.GetCurrentProcess().TotalProcessorTime;
 
-            var cpuUsedMs = (endCpuUsage - startCpuUsage).TotalMilliseconds;
-            var totalMsPassed = (endTime - startTime).TotalMilliseconds;
-            var cpuUsageTotal = cpuUsedMs / (Environment.ProcessorCount * totalMsPassed);
+            var cpuUsedMs = (endCpu - startCpu).TotalMilliseconds;
+            var elapsedMs = (endTime - startTime).TotalMilliseconds;
+            if (elapsedMs <= 0)
+            {
+                return 0.0;
+            }
 
-            return cpuUsageTotal * 100.0;
+            var usage = cpuUsedMs / (Environment.ProcessorCount * elapsedMs) * 100.0;
+            return Math.Clamp(usage, 0.0, 100.0);
         }
         catch
         {
-            // Return 0 if we can't measure CPU usage
             return 0.0;
         }
     }
 
-    private double GetMemoryUsage()
+    /// <summary>
+    /// Parses the aggregate <c>cpu</c> line of <c>/proc/stat</c> into idle and total jiffies.
+    /// Returns null if the content has no parseable aggregate cpu line.
+    /// </summary>
+    internal static CpuSample? ParseProcStatCpu(string content)
+    {
+        using var reader = new StringReader(content);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            // The aggregate line is "cpu " followed by per-state counters across all cores.
+            if (!line.StartsWith("cpu ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            // parts[0] = "cpu", parts[1..] = user nice system idle iowait irq softirq steal ...
+            if (parts.Length < 5)
+            {
+                return null;
+            }
+
+            long total = 0;
+            long idle = 0;
+            for (var i = 1; i < parts.Length; i++)
+            {
+                if (!long.TryParse(parts[i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+                {
+                    return null;
+                }
+
+                total += value;
+                // idle (index 4) + iowait (index 5) count as idle time.
+                if (i is 4 or 5)
+                {
+                    idle += value;
+                }
+            }
+
+            return new CpuSample(idle, total);
+        }
+
+        return null;
+    }
+
+    internal static double ComputeCpuUsagePercent(CpuSample first, CpuSample second)
+    {
+        var totalDelta = second.Total - first.Total;
+        var idleDelta = second.Idle - first.Idle;
+        if (totalDelta <= 0)
+        {
+            return 0.0;
+        }
+
+        var usage = (1.0 - (double)idleDelta / totalDelta) * 100.0;
+        return Math.Clamp(usage, 0.0, 100.0);
+    }
+
+    // ---- Memory -----------------------------------------------------------
+
+    private (double percent, long total, long used) GetMemory()
+    {
+        if (_isLinux && File.Exists(ProcMemInfoPath))
+        {
+            try
+            {
+                var parsed = ParseMemInfo(File.ReadAllText(ProcMemInfoPath));
+                if (parsed.HasValue)
+                {
+                    var (total, available) = parsed.Value;
+                    var used = Math.Max(0, total - available);
+                    var percent = total > 0 ? (double)used / total * 100.0 : 0.0;
+                    return (Math.Clamp(percent, 0.0, 100.0), total, used);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to read memory from {Path}; using fallback", ProcMemInfoPath);
+            }
+        }
+
+        // Degraded fallback (Windows/macOS/dev): process working set against available managed memory.
+        try
+        {
+            var total = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+            var used = Environment.WorkingSet;
+            var percent = total > 0 ? (double)used / total * 100.0 : 0.0;
+            return (Math.Clamp(percent, 0.0, 100.0), total, used);
+        }
+        catch
+        {
+            return (0.0, 0, 0);
+        }
+    }
+
+    /// <summary>
+    /// Parses <c>/proc/meminfo</c>, returning total and available memory in bytes.
+    /// Uses <c>MemAvailable</c> (not <c>MemFree</c>) so cache/buffers reclaimable by the
+    /// kernel are correctly counted as available. Returns null if either field is missing.
+    /// </summary>
+    internal static (long totalBytes, long availableBytes)? ParseMemInfo(string content)
+    {
+        long? totalKb = null;
+        long? availableKb = null;
+
+        using var reader = new StringReader(content);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (line.StartsWith("MemTotal:", StringComparison.Ordinal))
+            {
+                totalKb = ParseMemInfoValueKb(line);
+            }
+            else if (line.StartsWith("MemAvailable:", StringComparison.Ordinal))
+            {
+                availableKb = ParseMemInfoValueKb(line);
+            }
+
+            if (totalKb.HasValue && availableKb.HasValue)
+            {
+                break;
+            }
+        }
+
+        if (totalKb is null || availableKb is null)
+        {
+            return null;
+        }
+
+        return (totalKb.Value * 1024, availableKb.Value * 1024);
+    }
+
+    private static long? ParseMemInfoValueKb(string line)
+    {
+        // Format: "MemTotal:       8038600 kB"
+        var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2 && long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var kb))
+        {
+            return kb;
+        }
+
+        return null;
+    }
+
+    // ---- Disk -------------------------------------------------------------
+
+    private (double percent, long total, long used) GetDisk()
     {
         try
         {
-            var process = Process.GetCurrentProcess();
-            var usedMemory = process.WorkingSet64;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            var drive = new DriveInfo(_monitoredDiskPath);
+            if (drive.IsReady)
             {
-                // On Linux, try to read from /proc/meminfo
-                var totalMemory = GetTotalMemoryLinux();
-                if (totalMemory > 0)
-                {
-                    return (double)usedMemory / totalMemory * 100.0;
-                }
+                var total = drive.TotalSize;
+                var used = total - drive.AvailableFreeSpace;
+                var percent = total > 0 ? (double)used / total * 100.0 : 0.0;
+                return (Math.Clamp(percent, 0.0, 100.0), total, used);
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // On Windows, use GC for total memory
-                var gcMemoryInfo = GC.GetGCMemoryInfo();
-                var totalMemory = gcMemoryInfo.TotalAvailableMemoryBytes;
-                if (totalMemory > 0)
-                {
-                    return (double)usedMemory / totalMemory * 100.0;
-                }
-            }
-
-            // Fallback: return percentage based on 8GB assumption
-            return (double)usedMemory / (8L * 1024 * 1024 * 1024) * 100.0;
         }
-        catch
+        catch (Exception ex)
         {
-            return 0.0;
+            _logger.LogWarning(ex, "Failed to read disk usage for {Path}", _monitoredDiskPath);
         }
+
+        return (0.0, 0, 0);
     }
 
-    private double GetDiskUsage()
-    {
-        try
-        {
-            var drive = DriveInfo.GetDrives()
-                .FirstOrDefault(d => d.IsReady && d.DriveType == DriveType.Fixed);
-
-            if (drive != null)
-            {
-                var totalSize = drive.TotalSize;
-                var freeSpace = drive.AvailableFreeSpace;
-                var usedSpace = totalSize - freeSpace;
-
-                return (double)usedSpace / totalSize * 100.0;
-            }
-
-            return 0.0;
-        }
-        catch
-        {
-            return 0.0;
-        }
-    }
+    // ---- Uptime -----------------------------------------------------------
 
     private long GetUptime()
     {
-        return (long)(DateTime.UtcNow - _startTime).TotalSeconds;
+        if (_isLinux && File.Exists(ProcUptimePath))
+        {
+            try
+            {
+                var parsed = ParseUptime(File.ReadAllText(ProcUptimePath));
+                if (parsed.HasValue)
+                {
+                    return parsed.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to read uptime from {Path}; using fallback", ProcUptimePath);
+            }
+        }
+
+        // Cross-platform fallback: milliseconds since system boot (.NET 6+).
+        return Environment.TickCount64 / 1000;
     }
 
-    private long GetTotalMemoryLinux()
+    /// <summary>
+    /// Parses <c>/proc/uptime</c>, whose first field is seconds since boot (e.g. "12345.67 6789.01").
+    /// </summary>
+    internal static long? ParseUptime(string content)
+    {
+        var firstField = content.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        if (firstField is not null &&
+            double.TryParse(firstField, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
+        {
+            return (long)seconds;
+        }
+
+        return null;
+    }
+
+    // ---- Containers -------------------------------------------------------
+
+    private async Task<int> GetRunningContainerCountAsync(CancellationToken cancellationToken)
     {
         try
         {
-            if (!File.Exists("/proc/meminfo"))
-            {
-                return 0;
-            }
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(ContainerCountTimeout);
 
-            var lines = File.ReadAllLines("/proc/meminfo");
-            var memTotalLine = lines.FirstOrDefault(l => l.StartsWith("MemTotal:"));
-
-            if (memTotalLine == null)
-            {
-                return 0;
-            }
-
-            var parts = memTotalLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length >= 2 && long.TryParse(parts[1], out var memKb))
-            {
-                return memKb * 1024; // Convert KB to bytes
-            }
-
-            return 0;
+            var containers = await _containerManager.GetRunningContainersAsync(timeoutCts.Token);
+            return containers.Count;
         }
-        catch
+        catch (Exception ex)
         {
+            // Docker may be slow or unavailable — never let it block the heartbeat.
+            _logger.LogWarning(ex, "Failed to collect running container count; reporting 0");
             return 0;
         }
     }
 }
+
+/// <summary>Idle and total CPU jiffies sampled from <c>/proc/stat</c>.</summary>
+internal readonly record struct CpuSample(long Idle, long Total);

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Security/CsrGenerator.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Security/CsrGenerator.cs
@@ -1,0 +1,41 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using SignalBeam.EdgeAgent.Application.Services;
+
+namespace SignalBeam.EdgeAgent.Infrastructure.Security;
+
+/// <summary>
+/// Generates an RSA key pair and a PKCS#10 CSR using System.Security.Cryptography.
+/// The private key is returned to the caller to be stored locally and never transmitted.
+/// </summary>
+public sealed class CsrGenerator : ICsrGenerator
+{
+    private const int RsaKeySize = 2048;
+
+    public (string CsrPem, string PrivateKeyPem) GenerateCsr(string subject)
+    {
+        using var rsa = RSA.Create(RsaKeySize);
+
+        var request = new CertificateRequest(
+            subject,
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        var csrPem = request.CreateSigningRequestPem();
+        var privateKeyPem = ExportPrivateKeyToPem(rsa);
+
+        return (csrPem, privateKeyPem);
+    }
+
+    private static string ExportPrivateKeyToPem(RSA rsa)
+    {
+        var privateKeyBytes = rsa.ExportPkcs8PrivateKey();
+        var sb = new StringBuilder();
+        sb.AppendLine("-----BEGIN PRIVATE KEY-----");
+        sb.AppendLine(Convert.ToBase64String(privateKeyBytes, Base64FormattingOptions.InsertLineBreaks));
+        sb.AppendLine("-----END PRIVATE KEY-----");
+        return sb.ToString();
+    }
+}

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Storage/FileCertificateStore.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Storage/FileCertificateStore.cs
@@ -1,0 +1,60 @@
+using SignalBeam.EdgeAgent.Application.Services;
+
+namespace SignalBeam.EdgeAgent.Infrastructure.Storage;
+
+/// <summary>
+/// Stores mTLS certificate material as PEM files in a configured directory. The private key is
+/// written with owner-only permissions (0600) on Unix. Writes go to temp files first and are then
+/// moved into place so a partial write never leaves a half-written key.
+/// </summary>
+public sealed class FileCertificateStore : ICertificateStore
+{
+    private const string CertFileName = "device.crt";
+    private const string KeyFileName = "device.key";
+    private const string CaFileName = "ca.crt";
+
+    private readonly string _directory;
+
+    public FileCertificateStore(string directory)
+    {
+        _directory = directory;
+    }
+
+    public async Task<StoredCertificatePaths> SaveAsync(
+        string certificatePem,
+        string privateKeyPem,
+        string caCertificatePem,
+        CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(_directory);
+
+        var certPath = Path.Combine(_directory, CertFileName);
+        var keyPath = Path.Combine(_directory, KeyFileName);
+        var caPath = Path.Combine(_directory, CaFileName);
+
+        await WriteAtomicAsync(keyPath, privateKeyPem, ownerOnly: true, cancellationToken);
+        await WriteAtomicAsync(certPath, certificatePem, ownerOnly: false, cancellationToken);
+        await WriteAtomicAsync(caPath, caCertificatePem, ownerOnly: false, cancellationToken);
+
+        return new StoredCertificatePaths(certPath, keyPath, caPath);
+    }
+
+    private static async Task WriteAtomicAsync(
+        string path,
+        string content,
+        bool ownerOnly,
+        CancellationToken cancellationToken)
+    {
+        var tempPath = path + ".tmp";
+
+        // Create the file with restrictive permissions BEFORE writing sensitive content (Unix).
+        if (ownerOnly && !OperatingSystem.IsWindows())
+        {
+            await File.WriteAllTextAsync(tempPath, string.Empty, cancellationToken);
+            File.SetUnixFileMode(tempPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+
+        await File.WriteAllTextAsync(tempPath, content, cancellationToken);
+        File.Move(tempPath, path, overwrite: true);
+    }
+}

--- a/src/Shared/SignalBeam.Domain/Entities/Device.cs
+++ b/src/Shared/SignalBeam.Domain/Entities/Device.cs
@@ -67,6 +67,12 @@ public class Device : AggregateRoot<DeviceId>
     /// </summary>
     public DeviceRegistrationStatus RegistrationStatus { get; private set; }
 
+    /// <summary>
+    /// When the device claimed its API key via the one-time claim flow (null = not yet claimed).
+    /// Used to enforce single-use key delivery after approval.
+    /// </summary>
+    public DateTimeOffset? KeyClaimedAt { get; private set; }
+
     // EF Core constructor
     private Device() : base()
     {
@@ -246,6 +252,25 @@ public class Device : AggregateRoot<DeviceId>
 
         RegistrationStatus = DeviceRegistrationStatus.Approved;
         RaiseDomainEvent(new DeviceRegistrationApprovedEvent(Id, approvedAt));
+    }
+
+    /// <summary>
+    /// Whether the device may claim its API key through the one-time claim flow:
+    /// it is approved and has not claimed a key yet.
+    /// </summary>
+    public bool IsKeyClaimAvailable =>
+        RegistrationStatus == DeviceRegistrationStatus.Approved && KeyClaimedAt is null;
+
+    /// <summary>
+    /// Records that the device has claimed its API key, closing the one-time claim window.
+    /// Further key changes must go through rotation.
+    /// </summary>
+    public void MarkKeyClaimed(DateTimeOffset claimedAt)
+    {
+        if (RegistrationStatus != DeviceRegistrationStatus.Approved)
+            throw new InvalidOperationException("Cannot claim an API key before the device is approved.");
+
+        KeyClaimedAt = claimedAt;
     }
 
     /// <summary>

--- a/src/Shared/SignalBeam.Domain/Entities/DeviceRegistrationToken.cs
+++ b/src/Shared/SignalBeam.Domain/Entities/DeviceRegistrationToken.cs
@@ -22,7 +22,8 @@ public class DeviceRegistrationToken : Entity<Guid>
         DateTimeOffset expiresAt,
         string? createdBy,
         string? description,
-        int? maxUses)
+        int? maxUses,
+        bool autoApprove)
         : base(id)
     {
         TenantId = tenantId;
@@ -33,6 +34,7 @@ public class DeviceRegistrationToken : Entity<Guid>
         CreatedBy = createdBy;
         Description = description;
         MaxUses = maxUses;
+        AutoApprove = autoApprove;
         CurrentUses = 0;
         IsRevoked = false;
         IsUsed = false;
@@ -80,6 +82,12 @@ public class DeviceRegistrationToken : Entity<Guid>
     /// Maximum number of times this token can be used (null = unlimited).
     /// </summary>
     public int? MaxUses { get; private set; }
+
+    /// <summary>
+    /// When true, devices registering with this token are approved automatically,
+    /// enabling zero-touch fleet provisioning for trusted tokens.
+    /// </summary>
+    public bool AutoApprove { get; private set; }
 
     /// <summary>
     /// Current number of times this token has been used.
@@ -140,7 +148,8 @@ public class DeviceRegistrationToken : Entity<Guid>
         DateTimeOffset expiresAt,
         string? createdBy = null,
         string? description = null,
-        int? maxUses = null)
+        int? maxUses = null,
+        bool autoApprove = false)
     {
         return new DeviceRegistrationToken(
             Guid.NewGuid(),
@@ -151,7 +160,8 @@ public class DeviceRegistrationToken : Entity<Guid>
             expiresAt,
             createdBy,
             description,
-            maxUses);
+            maxUses,
+            autoApprove);
     }
 
     /// <summary>

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
@@ -167,32 +167,34 @@ public class DeviceAuthenticationMiddleware
     /// </summary>
     private static bool IsRegistrationHandshake(HttpRequest request)
     {
-        if (!request.Path.StartsWithSegments("/api/devices"))
+        var path = (request.Path.Value ?? string.Empty).Trim('/');
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        if (segments.Length < 2 ||
+            !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase) ||
+            !segments[1].Equals("devices", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
 
-        var path = (request.Path.Value ?? string.Empty).TrimEnd('/');
-
         // POST /api/devices — device self-registration (registration token verified in handler)
-        if (HttpMethods.IsPost(request.Method) &&
-            string.Equals(path, "/api/devices", StringComparison.OrdinalIgnoreCase))
+        if (segments.Length == 2)
         {
-            return true;
+            return HttpMethods.IsPost(request.Method);
         }
 
-        // GET /api/devices/{id}/registration-status — status only, returns no secrets
-        if (HttpMethods.IsGet(request.Method) &&
-            path.EndsWith("/registration-status", StringComparison.OrdinalIgnoreCase))
+        // /api/devices/{guid}/{sub} — only the registration-status and claim-key sub-resources.
+        // Requiring a parseable GUID segment prevents an artificial path from matching by suffix.
+        if (segments.Length == 4 && Guid.TryParse(segments[2], out _))
         {
-            return true;
-        }
-
-        // POST /api/devices/{id}/claim-key — one-time key claim (registration token verified in handler)
-        if (HttpMethods.IsPost(request.Method) &&
-            path.EndsWith("/claim-key", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
+            return segments[3] switch
+            {
+                _ when segments[3].Equals("registration-status", StringComparison.OrdinalIgnoreCase)
+                    => HttpMethods.IsGet(request.Method), // status only, returns no secrets
+                _ when segments[3].Equals("claim-key", StringComparison.OrdinalIgnoreCase)
+                    => HttpMethods.IsPost(request.Method), // one-time key claim, token verified in handler
+                _ => false
+            };
         }
 
         return false;

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
@@ -42,6 +42,15 @@ public class DeviceAuthenticationMiddleware
             return;
         }
 
+        // Skip device-key auth for the registration handshake. These endpoints run before the
+        // device holds an API key and are each authenticated by other means in their handlers:
+        // register and claim-key verify the registration token; registration-status returns no secrets.
+        if (IsRegistrationHandshake(context.Request))
+        {
+            await _next(context);
+            return;
+        }
+
         // [1] Try certificate authentication first (if mTLS is configured)
         var clientCert = context.Connection.ClientCertificate;
         if (clientCert != null && certificateValidator != null)
@@ -149,6 +158,44 @@ public class DeviceAuthenticationMiddleware
         await RespondUnauthorized(context,
             "INVALID_API_KEY",
             "The provided API key is invalid or has expired.");
+    }
+
+    /// <summary>
+    /// Identifies the registration-handshake endpoints that must be reachable before a device
+    /// has an API key: device registration, approval-status polling, and the one-time key claim.
+    /// Uses exact method + path matching to avoid exposing other device endpoints.
+    /// </summary>
+    private static bool IsRegistrationHandshake(HttpRequest request)
+    {
+        if (!request.Path.StartsWithSegments("/api/devices"))
+        {
+            return false;
+        }
+
+        var path = (request.Path.Value ?? string.Empty).TrimEnd('/');
+
+        // POST /api/devices — device self-registration (registration token verified in handler)
+        if (HttpMethods.IsPost(request.Method) &&
+            string.Equals(path, "/api/devices", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // GET /api/devices/{id}/registration-status — status only, returns no secrets
+        if (HttpMethods.IsGet(request.Method) &&
+            path.EndsWith("/registration-status", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // POST /api/devices/{id}/claim-key — one-time key claim (registration token verified in handler)
+        if (HttpMethods.IsPost(request.Method) &&
+            path.EndsWith("/claim-key", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private void SetUserPrincipal(

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/AuthenticationAndRateLimitingTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/AuthenticationAndRateLimitingTests.cs
@@ -43,15 +43,12 @@ public class AuthenticationAndRateLimitingTests : IClassFixture<DeviceManagerWeb
     [Fact]
     public async Task Request_WithInvalidApiKey_ReturnsUnauthorized()
     {
-        // Arrange
+        // Arrange — registration endpoints are now a public handshake (#279), so assert the
+        // middleware rejection against a still-protected endpoint (device lookup).
         var client = _factory.CreateAuthenticatedClient("");
-        var request = new RegisterDeviceCommand(
-            TenantId: _factory.DefaultTenantId,
-            DeviceId: Guid.NewGuid(),
-            Name: "Test Device");
 
         // Act
-        var response = await client.PostAsJsonAsync("/api/devices", request);
+        var response = await client.GetAsync($"/api/devices/{Guid.NewGuid()}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/DeviceEndpointsTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/DeviceEndpointsTests.cs
@@ -46,9 +46,11 @@ public class DeviceEndpointsTests : IClassFixture<DeviceManagerWebApplicationFac
     }
 
     [Fact]
-    public async Task RegisterDevice_WithoutAuthentication_ReturnsUnauthorized()
+    public async Task RegisterDevice_WithoutAuthentication_IsReachableAsPublicHandshake()
     {
-        // Arrange
+        // Registration is a public handshake endpoint (#279): a brand-new device has no API key
+        // yet, so the device-auth middleware must not reject it. Authorization is enforced
+        // in-handler via the registration token, not by requiring a pre-shared API key.
         var unauthenticatedClient = _factory.CreateClient();
         var request = new RegisterDeviceCommand(
             TenantId: _factory.DefaultTenantId,
@@ -58,8 +60,8 @@ public class DeviceEndpointsTests : IClassFixture<DeviceManagerWebApplicationFac
         // Act
         var response = await unauthenticatedClient.PostAsJsonAsync("/api/devices", request);
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // Assert — reachable (not blocked by device-auth middleware)
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
     }
 
     [Fact]

--- a/tests/SignalBeam.DeviceManager.Tests.Unit/CertificateAuthority/X509CertificateGeneratorCsrTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Unit/CertificateAuthority/X509CertificateGeneratorCsrTests.cs
@@ -1,0 +1,50 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using SignalBeam.DeviceManager.Infrastructure.CertificateAuthority;
+
+namespace SignalBeam.DeviceManager.Tests.Unit.CertificateAuthority;
+
+public class X509CertificateGeneratorCsrTests
+{
+    private readonly X509CertificateGenerator _generator = new();
+
+    [Fact]
+    public void SignCertificateSigningRequest_ProducesClientCertChainingToCa()
+    {
+        // Arrange: a root CA, and a device-generated CSR (private key stays with the device).
+        var ca = _generator.GenerateRootCaCertificate("CN=Test CA, O=SignalBeam, C=US", validityDays: 3650);
+
+        using var deviceKey = RSA.Create(2048);
+        var deviceRequest = new CertificateRequest(
+            "CN=device-abc, O=SignalBeam", deviceKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var csrPem = deviceRequest.CreateSigningRequestPem();
+
+        var serial = Convert.ToHexString(RandomNumberGenerator.GetBytes(19)); // positive, even-length hex
+
+        // Act
+        var signedPem = _generator.SignCertificateSigningRequest(
+            csrPem, ca.PrivateKeyPem, ca.CertificatePem, serial, validityDays: 90);
+
+        // Assert
+        using var signed = X509Certificate2.CreateFromPem(signedPem);
+        using var caCert = X509Certificate2.CreateFromPem(ca.CertificatePem);
+
+        signed.Subject.Should().Contain("device-abc");
+        signed.IssuerName.Name.Should().Be(caCert.SubjectName.Name);
+
+        // The signed cert's public key must match the device's retained private key.
+        signed.GetRSAPublicKey()!.ExportSubjectPublicKeyInfo()
+            .Should().Equal(deviceKey.ExportSubjectPublicKeyInfo());
+
+        // clientAuth EKU is present (CA-controlled, not from the CSR).
+        var eku = signed.Extensions.OfType<X509EnhancedKeyUsageExtension>().Single();
+        eku.EnhancedKeyUsages.Cast<Oid>().Select(o => o.Value).Should().Contain("1.3.6.1.5.5.7.3.2");
+
+        // It chains to the CA.
+        using var chain = new X509Chain();
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+        chain.ChainPolicy.CustomTrustStore.Add(caCert);
+        chain.Build(signed).Should().BeTrue("the signed device certificate should chain to the CA");
+    }
+}

--- a/tests/SignalBeam.DeviceManager.Tests.Unit/Commands/ClaimDeviceApiKeyHandlerTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Unit/Commands/ClaimDeviceApiKeyHandlerTests.cs
@@ -1,0 +1,136 @@
+using SignalBeam.DeviceManager.Application.Commands;
+using SignalBeam.DeviceManager.Application.Repositories;
+using SignalBeam.Domain.Entities;
+using SignalBeam.Domain.Enums;
+using SignalBeam.Domain.ValueObjects;
+using SignalBeam.Shared.Infrastructure.Authentication;
+using SignalBeam.Shared.Infrastructure.Results;
+
+namespace SignalBeam.DeviceManager.Tests.Unit.Commands;
+
+public class ClaimDeviceApiKeyHandlerTests
+{
+    private const string ValidToken = "sbt_abc12345_secret";
+    private const string TokenPrefix = "sbt_abc12345";
+
+    private readonly IDeviceRepository _deviceRepository = Substitute.For<IDeviceRepository>();
+    private readonly IDeviceApiKeyRepository _apiKeyRepository = Substitute.For<IDeviceApiKeyRepository>();
+    private readonly IDeviceRegistrationTokenRepository _tokenRepository = Substitute.For<IDeviceRegistrationTokenRepository>();
+    private readonly IDeviceApiKeyService _apiKeyService = Substitute.For<IDeviceApiKeyService>();
+    private readonly IRegistrationTokenService _tokenService = Substitute.For<IRegistrationTokenService>();
+    private readonly ClaimDeviceApiKeyHandler _handler;
+
+    private readonly DeviceId _deviceId = DeviceId.New();
+    private readonly TenantId _tenantId = TenantId.New();
+
+    public ClaimDeviceApiKeyHandlerTests()
+    {
+        _handler = new ClaimDeviceApiKeyHandler(
+            _deviceRepository, _apiKeyRepository, _tokenRepository, _apiKeyService, _tokenService);
+
+        _apiKeyRepository.GetActiveByDeviceIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>())
+            .Returns(new List<DeviceApiKey>());
+        _apiKeyService.GenerateApiKey(Arg.Any<DeviceId>())
+            .Returns(("sb_device_ab12_secret", "key-hash", "ab12"));
+        _tokenService.ValidateToken(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+    }
+
+    private Device ApprovedDevice()
+    {
+        var device = Device.Register(_deviceId, _tenantId, "pi-5", DateTimeOffset.UtcNow);
+        device.ApproveRegistration(DateTimeOffset.UtcNow);
+        return device;
+    }
+
+    private DeviceRegistrationToken TokenUsedBy(DeviceId deviceId, TenantId? tenantId = null)
+    {
+        var token = DeviceRegistrationToken.Create(
+            tenantId ?? _tenantId, "token-hash", TokenPrefix, DateTimeOffset.UtcNow.AddDays(1));
+        token.MarkAsUsed(deviceId);
+        return token;
+    }
+
+    [Fact]
+    public async Task Handle_ApprovedDeviceWithBoundToken_ReturnsKeyAndMarksClaimed()
+    {
+        var device = ApprovedDevice();
+        _deviceRepository.GetByIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>()).Returns(device);
+        _tokenRepository.GetByPrefixAsync(TokenPrefix, Arg.Any<CancellationToken>()).Returns(TokenUsedBy(_deviceId));
+
+        var result = await _handler.Handle(new ClaimDeviceApiKeyCommand(_deviceId.Value, ValidToken), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ApiKey.Should().Be("sb_device_ab12_secret");
+        device.KeyClaimedAt.Should().NotBeNull();
+        device.IsKeyClaimAvailable.Should().BeFalse();
+        await _apiKeyRepository.Received(1).AddAsync(Arg.Any<DeviceApiKey>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_DeviceNotApproved_ReturnsForbidden()
+    {
+        var device = Device.Register(_deviceId, _tenantId, "pi-5", DateTimeOffset.UtcNow); // still Pending
+        _deviceRepository.GetByIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>()).Returns(device);
+
+        var result = await _handler.Handle(new ClaimDeviceApiKeyCommand(_deviceId.Value, ValidToken), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Type.Should().Be(ErrorType.Forbidden);
+        result.Error.Code.Should().Be("DEVICE_NOT_APPROVED");
+    }
+
+    [Fact]
+    public async Task Handle_KeyAlreadyClaimed_ReturnsConflict()
+    {
+        var device = ApprovedDevice();
+        device.MarkKeyClaimed(DateTimeOffset.UtcNow);
+        _deviceRepository.GetByIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>()).Returns(device);
+
+        var result = await _handler.Handle(new ClaimDeviceApiKeyCommand(_deviceId.Value, ValidToken), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Type.Should().Be(ErrorType.Conflict);
+        result.Error.Code.Should().Be("KEY_ALREADY_CLAIMED");
+    }
+
+    [Fact]
+    public async Task Handle_TokenUsedByDifferentDevice_ReturnsUnauthorized()
+    {
+        var device = ApprovedDevice();
+        _deviceRepository.GetByIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>()).Returns(device);
+        // Token was used by some OTHER device
+        _tokenRepository.GetByPrefixAsync(TokenPrefix, Arg.Any<CancellationToken>()).Returns(TokenUsedBy(DeviceId.New()));
+
+        var result = await _handler.Handle(new ClaimDeviceApiKeyCommand(_deviceId.Value, ValidToken), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Type.Should().Be(ErrorType.Unauthorized);
+        result.Error.Code.Should().Be("RegistrationToken.DeviceMismatch");
+        device.KeyClaimedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_InvalidTokenSecret_ReturnsUnauthorized()
+    {
+        var device = ApprovedDevice();
+        _deviceRepository.GetByIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>()).Returns(device);
+        _tokenRepository.GetByPrefixAsync(TokenPrefix, Arg.Any<CancellationToken>()).Returns(TokenUsedBy(_deviceId));
+        _tokenService.ValidateToken(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+
+        var result = await _handler.Handle(new ClaimDeviceApiKeyCommand(_deviceId.Value, ValidToken), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Type.Should().Be(ErrorType.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Handle_DeviceNotFound_ReturnsNotFound()
+    {
+        _deviceRepository.GetByIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>()).Returns((Device?)null);
+
+        var result = await _handler.Handle(new ClaimDeviceApiKeyCommand(_deviceId.Value, ValidToken), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Type.Should().Be(ErrorType.NotFound);
+    }
+}

--- a/tests/SignalBeam.DeviceManager.Tests.Unit/Commands/ClaimDeviceApiKeyHandlerTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Unit/Commands/ClaimDeviceApiKeyHandlerTests.cs
@@ -110,6 +110,23 @@ public class ClaimDeviceApiKeyHandlerTests
     }
 
     [Fact]
+    public async Task Handle_RevokedToken_ReturnsUnauthorized()
+    {
+        var device = ApprovedDevice();
+        _deviceRepository.GetByIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>()).Returns(device);
+        var token = TokenUsedBy(_deviceId);
+        token.Revoke("admin");
+        _tokenRepository.GetByPrefixAsync(TokenPrefix, Arg.Any<CancellationToken>()).Returns(token);
+
+        var result = await _handler.Handle(new ClaimDeviceApiKeyCommand(_deviceId.Value, ValidToken), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Type.Should().Be(ErrorType.Unauthorized);
+        result.Error.Code.Should().Be("RegistrationToken.Expired");
+        device.KeyClaimedAt.Should().BeNull();
+    }
+
+    [Fact]
     public async Task Handle_InvalidTokenSecret_ReturnsUnauthorized()
     {
         var device = ApprovedDevice();

--- a/tests/SignalBeam.DeviceManager.Tests.Unit/Commands/RegisterDeviceHandlerTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Unit/Commands/RegisterDeviceHandlerTests.cs
@@ -2,6 +2,7 @@ using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Repositories;
 using SignalBeam.DeviceManager.Application.Services;
 using SignalBeam.Domain.Entities;
+using SignalBeam.Domain.Enums;
 using SignalBeam.Domain.ValueObjects;
 using SignalBeam.Shared.Infrastructure.Authentication;
 using SignalBeam.Shared.Infrastructure.Results;
@@ -159,5 +160,62 @@ public class RegisterDeviceHandlerTests
         await _quotaValidator.Received(1).CheckDeviceQuotaAsync(
             Arg.Is<TenantId>(t => t.Value == tenantId),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AutoApproveToken_ApprovesDeviceOnRegistration()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var command = new RegisterDeviceCommand(
+            TenantId: tenantId,
+            Name: "pi-5",
+            DeviceId: Guid.NewGuid(),
+            RegistrationToken: "sbt_abc12345_secret");
+
+        _deviceRepository.GetByIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>())
+            .Returns((Device?)null);
+
+        var token = DeviceRegistrationToken.Create(
+            new TenantId(tenantId), "hash", "sbt_abc12345", DateTimeOffset.UtcNow.AddDays(1), autoApprove: true);
+        _tokenRepository.GetByPrefixAsync("sbt_abc12345", Arg.Any<CancellationToken>()).Returns(token);
+        _tokenService.ValidateToken(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(DeviceRegistrationStatus.Approved.ToString());
+        await _deviceRepository.Received(1).AddAsync(
+            Arg.Is<Device>(d => d.RegistrationStatus == DeviceRegistrationStatus.Approved),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NonAutoApproveToken_LeavesDevicePending()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var command = new RegisterDeviceCommand(
+            TenantId: tenantId,
+            Name: "pi-5",
+            DeviceId: Guid.NewGuid(),
+            RegistrationToken: "sbt_abc12345_secret");
+
+        _deviceRepository.GetByIdAsync(Arg.Any<DeviceId>(), Arg.Any<CancellationToken>())
+            .Returns((Device?)null);
+
+        var token = DeviceRegistrationToken.Create(
+            new TenantId(tenantId), "hash", "sbt_abc12345", DateTimeOffset.UtcNow.AddDays(1), autoApprove: false);
+        _tokenRepository.GetByPrefixAsync("sbt_abc12345", Arg.Any<CancellationToken>()).Returns(token);
+        _tokenService.ValidateToken(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(DeviceRegistrationStatus.Pending.ToString());
     }
 }

--- a/tests/SignalBeam.EdgeAgent.Tests.Unit/Cloud/KeyRotationServiceTests.cs
+++ b/tests/SignalBeam.EdgeAgent.Tests.Unit/Cloud/KeyRotationServiceTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Logging;
+using SignalBeam.EdgeAgent.Application.Models;
+using SignalBeam.EdgeAgent.Application.Services;
+using SignalBeam.EdgeAgent.Infrastructure.Cloud;
+
+namespace SignalBeam.EdgeAgent.Tests.Unit.Cloud;
+
+public class KeyRotationServiceTests
+{
+    private const int ThresholdDays = 7;
+
+    private readonly ICloudClient _cloudClient = Substitute.For<ICloudClient>();
+    private readonly IDeviceCredentialsStore _store = Substitute.For<IDeviceCredentialsStore>();
+    private readonly KeyRotationService _sut;
+
+    private readonly Guid _deviceId = Guid.NewGuid();
+
+    public KeyRotationServiceTests()
+    {
+        var logger = Substitute.For<ILogger<KeyRotationService>>();
+        _sut = new KeyRotationService(_cloudClient, _store, logger, ThresholdDays);
+    }
+
+    private DeviceCredentials Credentials(string? apiKey, DateTimeOffset? expiresAt) => new()
+    {
+        DeviceId = _deviceId,
+        ApiKey = apiKey,
+        ApiKeyExpiresAt = expiresAt
+    };
+
+    [Fact]
+    public async Task CheckAndRotate_KeyExpiringWithinThreshold_Rotates()
+    {
+        var credentials = Credentials("sb_device_old", DateTimeOffset.UtcNow.AddDays(3));
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns(credentials);
+        var newExpiry = DateTimeOffset.UtcNow.AddDays(90);
+        _cloudClient.RotateApiKeyAsync(_deviceId, Arg.Any<CancellationToken>())
+            .Returns(new ClaimedApiKey("sb_device_new", newExpiry));
+
+        var rotated = await _sut.CheckAndRotateAsync();
+
+        rotated.Should().BeTrue();
+        credentials.ApiKey.Should().Be("sb_device_new");
+        await _store.Received(1).SaveCredentialsAsync(
+            Arg.Is<DeviceCredentials>(c => c.ApiKey == "sb_device_new"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckAndRotate_KeyNotNearExpiry_DoesNotRotate()
+    {
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>())
+            .Returns(Credentials("sb_device_old", DateTimeOffset.UtcNow.AddDays(60)));
+
+        var rotated = await _sut.CheckAndRotateAsync();
+
+        rotated.Should().BeFalse();
+        await _cloudClient.DidNotReceive().RotateApiKeyAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckAndRotate_KeyAlreadyExpired_DoesNotRotate()
+    {
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>())
+            .Returns(Credentials("sb_device_old", DateTimeOffset.UtcNow.AddDays(-1)));
+
+        var rotated = await _sut.CheckAndRotateAsync();
+
+        // Can't authenticate a rotation with an expired key.
+        rotated.Should().BeFalse();
+        await _cloudClient.DidNotReceive().RotateApiKeyAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckAndRotate_NoExpiry_DoesNotRotate()
+    {
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>())
+            .Returns(Credentials("sb_device_old", expiresAt: null));
+
+        var rotated = await _sut.CheckAndRotateAsync();
+
+        rotated.Should().BeFalse();
+        await _cloudClient.DidNotReceive().RotateApiKeyAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckAndRotate_NoCredentials_DoesNotRotate()
+    {
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns((DeviceCredentials?)null);
+
+        var rotated = await _sut.CheckAndRotateAsync();
+
+        rotated.Should().BeFalse();
+    }
+}

--- a/tests/SignalBeam.EdgeAgent.Tests.Unit/Commands/CheckRegistrationStatusCommandHandlerTests.cs
+++ b/tests/SignalBeam.EdgeAgent.Tests.Unit/Commands/CheckRegistrationStatusCommandHandlerTests.cs
@@ -1,0 +1,122 @@
+using Microsoft.Extensions.Logging;
+using SignalBeam.EdgeAgent.Application.Commands;
+using SignalBeam.EdgeAgent.Application.Models;
+using SignalBeam.EdgeAgent.Application.Services;
+
+namespace SignalBeam.EdgeAgent.Tests.Unit.Commands;
+
+public class CheckRegistrationStatusCommandHandlerTests
+{
+    private readonly ICloudClient _cloudClient = Substitute.For<ICloudClient>();
+    private readonly IDeviceCredentialsStore _store = Substitute.For<IDeviceCredentialsStore>();
+    private readonly CheckRegistrationStatusCommandHandler _handler;
+
+    private readonly Guid _deviceId = Guid.NewGuid();
+
+    public CheckRegistrationStatusCommandHandlerTests()
+    {
+        var logger = Substitute.For<ILogger<CheckRegistrationStatusCommandHandler>>();
+        _handler = new CheckRegistrationStatusCommandHandler(_cloudClient, _store, logger);
+    }
+
+    private DeviceCredentials PendingCredentials(string? token = "sbt_abc12345_secret") => new()
+    {
+        DeviceId = _deviceId,
+        RegistrationStatus = "Pending",
+        ApiKey = null,
+        RegistrationToken = token
+    };
+
+    [Fact]
+    public async Task Handle_ApprovedWithClaimAvailable_ClaimsAndStoresKey()
+    {
+        var credentials = PendingCredentials();
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns(credentials);
+        _cloudClient.CheckRegistrationStatusAsync(_deviceId, Arg.Any<CancellationToken>())
+            .Returns(new RegistrationStatusResponse("Approved", ApiKey: null, KeyClaimAvailable: true));
+        var expiry = DateTimeOffset.UtcNow.AddDays(90);
+        _cloudClient.ClaimApiKeyAsync(_deviceId, "sbt_abc12345_secret", Arg.Any<CancellationToken>())
+            .Returns(new ClaimedApiKey("sb_device_ab12_secret", expiry));
+
+        var result = await _handler.Handle(new CheckRegistrationStatusCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ApiKey.Should().Be("sb_device_ab12_secret");
+        result.Value.IsApproved.Should().BeTrue();
+        await _cloudClient.Received(1).ClaimApiKeyAsync(_deviceId, "sbt_abc12345_secret", Arg.Any<CancellationToken>());
+        await _store.Received().SaveCredentialsAsync(
+            Arg.Is<DeviceCredentials>(c => c.ApiKey == "sb_device_ab12_secret"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ApprovedButClaimNotAvailable_DoesNotClaim()
+    {
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns(PendingCredentials());
+        _cloudClient.CheckRegistrationStatusAsync(_deviceId, Arg.Any<CancellationToken>())
+            .Returns(new RegistrationStatusResponse("Approved", ApiKey: null, KeyClaimAvailable: false));
+
+        var result = await _handler.Handle(new CheckRegistrationStatusCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ApiKey.Should().BeNull();
+        await _cloudClient.DidNotReceive().ClaimApiKeyAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ClaimAvailableButNoToken_DoesNotClaim()
+    {
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns(PendingCredentials(token: null));
+        _cloudClient.CheckRegistrationStatusAsync(_deviceId, Arg.Any<CancellationToken>())
+            .Returns(new RegistrationStatusResponse("Approved", ApiKey: null, KeyClaimAvailable: true));
+
+        var result = await _handler.Handle(new CheckRegistrationStatusCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        await _cloudClient.DidNotReceive().ClaimApiKeyAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyApprovedWithLocalKey_ShortCircuits()
+    {
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns(new DeviceCredentials
+        {
+            DeviceId = _deviceId,
+            RegistrationStatus = "Approved",
+            ApiKey = "sb_device_existing"
+        });
+
+        var result = await _handler.Handle(new CheckRegistrationStatusCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ApiKey.Should().Be("sb_device_existing");
+        await _cloudClient.DidNotReceive().CheckRegistrationStatusAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NotRegistered_ReturnsFailure()
+    {
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns((DeviceCredentials?)null);
+
+        var result = await _handler.Handle(new CheckRegistrationStatusCommand(), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ClaimThrows_DoesNotFailPoll()
+    {
+        _store.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns(PendingCredentials());
+        _cloudClient.CheckRegistrationStatusAsync(_deviceId, Arg.Any<CancellationToken>())
+            .Returns(new RegistrationStatusResponse("Approved", ApiKey: null, KeyClaimAvailable: true));
+        _cloudClient.ClaimApiKeyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<ClaimedApiKey>(_ => throw new HttpRequestException("boom"));
+
+        var result = await _handler.Handle(new CheckRegistrationStatusCommand(), CancellationToken.None);
+
+        // Transient claim failure must not fail the poll — next cycle retries.
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ApiKey.Should().BeNull();
+    }
+}

--- a/tests/SignalBeam.EdgeAgent.Tests.Unit/Commands/RequestCertificateCommandHandlerTests.cs
+++ b/tests/SignalBeam.EdgeAgent.Tests.Unit/Commands/RequestCertificateCommandHandlerTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Logging;
+using SignalBeam.EdgeAgent.Application.Commands;
+using SignalBeam.EdgeAgent.Application.Models;
+using SignalBeam.EdgeAgent.Application.Services;
+
+namespace SignalBeam.EdgeAgent.Tests.Unit.Commands;
+
+public class RequestCertificateCommandHandlerTests
+{
+    private readonly ICloudClient _cloudClient = Substitute.For<ICloudClient>();
+    private readonly ICsrGenerator _csrGenerator = Substitute.For<ICsrGenerator>();
+    private readonly ICertificateStore _certificateStore = Substitute.For<ICertificateStore>();
+    private readonly IDeviceCredentialsStore _credentialsStore = Substitute.For<IDeviceCredentialsStore>();
+    private readonly RequestCertificateCommandHandler _handler;
+
+    private readonly Guid _deviceId = Guid.NewGuid();
+
+    public RequestCertificateCommandHandlerTests()
+    {
+        var logger = Substitute.For<ILogger<RequestCertificateCommandHandler>>();
+        _handler = new RequestCertificateCommandHandler(
+            _cloudClient, _csrGenerator, _certificateStore, _credentialsStore, logger);
+    }
+
+    [Fact]
+    public async Task Handle_GeneratesCsrSignsStoresAndUpdatesCredentials()
+    {
+        var credentials = new DeviceCredentials { DeviceId = _deviceId, ApiKey = "sb_device_x" };
+        _credentialsStore.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns(credentials);
+        _csrGenerator.GenerateCsr(Arg.Any<string>()).Returns(("csr-pem", "key-pem"));
+        var expiry = DateTimeOffset.UtcNow.AddDays(90);
+        _cloudClient.RequestCertificateAsync(_deviceId, "csr-pem", Arg.Any<CancellationToken>())
+            .Returns(new DeviceCertificateBundle("cert-pem", "ca-pem", "SERIAL123", expiry));
+        _certificateStore.SaveAsync("cert-pem", "key-pem", "ca-pem", Arg.Any<CancellationToken>())
+            .Returns(new StoredCertificatePaths("/certs/device.crt", "/certs/device.key", "/certs/ca.crt"));
+
+        var result = await _handler.Handle(new RequestCertificateCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.SerialNumber.Should().Be("SERIAL123");
+        credentials.ClientCertificatePath.Should().Be("/certs/device.crt");
+        credentials.ClientPrivateKeyPath.Should().Be("/certs/device.key");
+        credentials.CaCertificatePath.Should().Be("/certs/ca.crt");
+        credentials.CertificateSerialNumber.Should().Be("SERIAL123");
+        credentials.CertificateExpiresAt.Should().Be(expiry);
+        await _credentialsStore.Received(1).SaveCredentialsAsync(
+            Arg.Is<DeviceCredentials>(c => c.CertificateSerialNumber == "SERIAL123"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NotRegistered_ReturnsFailure()
+    {
+        _credentialsStore.LoadCredentialsAsync(Arg.Any<CancellationToken>()).Returns((DeviceCredentials?)null);
+
+        var result = await _handler.Handle(new RequestCertificateCommand(), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        await _cloudClient.DidNotReceive().RequestCertificateAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NoApiKey_ReturnsFailure()
+    {
+        _credentialsStore.LoadCredentialsAsync(Arg.Any<CancellationToken>())
+            .Returns(new DeviceCredentials { DeviceId = _deviceId, ApiKey = null });
+
+        var result = await _handler.Handle(new RequestCertificateCommand(), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        await _cloudClient.DidNotReceive().RequestCertificateAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/SignalBeam.EdgeAgent.Tests.Unit/Commands/SendHeartbeatCommandHandlerTests.cs
+++ b/tests/SignalBeam.EdgeAgent.Tests.Unit/Commands/SendHeartbeatCommandHandlerTests.cs
@@ -8,6 +8,7 @@ public class SendHeartbeatCommandHandlerTests
 {
     private readonly ICloudClient _cloudClient;
     private readonly IHeartbeatPublisher _heartbeatPublisher;
+    private readonly IMetricsPublisher _metricsPublisher;
     private readonly IMetricsCollector _metricsCollector;
     private readonly SendHeartbeatCommandHandler _handler;
 
@@ -15,10 +16,11 @@ public class SendHeartbeatCommandHandlerTests
     {
         _cloudClient = Substitute.For<ICloudClient>();
         _heartbeatPublisher = Substitute.For<IHeartbeatPublisher>();
+        _metricsPublisher = Substitute.For<IMetricsPublisher>();
         _metricsCollector = Substitute.For<IMetricsCollector>();
         var logger = Substitute.For<ILogger<SendHeartbeatCommandHandler>>();
         _handler = new SendHeartbeatCommandHandler(
-            _cloudClient, _heartbeatPublisher, _metricsCollector, logger);
+            _cloudClient, _heartbeatPublisher, _metricsPublisher, _metricsCollector, logger);
     }
 
     [Fact]
@@ -32,7 +34,8 @@ public class SendHeartbeatCommandHandlerTests
             CpuUsagePercent: 45.5,
             MemoryUsagePercent: 60.0,
             DiskUsagePercent: 75.0,
-            UptimeSeconds: 3600);
+            UptimeSeconds: 3600,
+            RunningContainers: 4);
 
         _metricsCollector.CollectMetricsAsync(Arg.Any<CancellationToken>())
             .Returns(metrics);
@@ -43,6 +46,8 @@ public class SendHeartbeatCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         await _metricsCollector.Received(1).CollectMetricsAsync(Arg.Any<CancellationToken>());
+        await _metricsPublisher.Received(1).PublishMetricsAsync(
+            deviceId, metrics, 4, Arg.Any<CancellationToken>());
         await _heartbeatPublisher.Received(1).PublishHeartbeatAsync(
             deviceId, "online", null, Arg.Any<CancellationToken>());
         await _cloudClient.Received(1).SendHeartbeatAsync(

--- a/tests/SignalBeam.EdgeAgent.Tests.Unit/Metrics/SystemMetricsCollectorTests.cs
+++ b/tests/SignalBeam.EdgeAgent.Tests.Unit/Metrics/SystemMetricsCollectorTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.Logging;
+using SignalBeam.EdgeAgent.Application.Services;
+using SignalBeam.EdgeAgent.Infrastructure.Metrics;
+
+namespace SignalBeam.EdgeAgent.Tests.Unit.Metrics;
+
+public class SystemMetricsCollectorTests
+{
+    private readonly IContainerManager _containerManager = Substitute.For<IContainerManager>();
+    private readonly ILogger<SystemMetricsCollector> _logger = Substitute.For<ILogger<SystemMetricsCollector>>();
+
+    // ---- CPU (/proc/stat) ------------------------------------------------
+
+    [Fact]
+    public void ParseProcStatCpu_AggregatesIdlePlusIowaitAndTotal()
+    {
+        // user=100 nice=0 system=100 idle=700 iowait=100 (+ zeros)
+        const string content = "cpu  100 0 100 700 100 0 0 0 0 0\ncpu0 50 0 50 350 50 0 0 0 0 0\n";
+
+        var sample = SystemMetricsCollector.ParseProcStatCpu(content);
+
+        sample.Should().NotBeNull();
+        sample!.Value.Total.Should().Be(1000); // 100+0+100+700+100
+        sample.Value.Idle.Should().Be(800);    // idle 700 + iowait 100
+    }
+
+    [Fact]
+    public void ParseProcStatCpu_ReturnsNull_WhenNoAggregateLine()
+    {
+        const string content = "cpu0 50 0 50 350 50 0\nintr 12345\n";
+
+        SystemMetricsCollector.ParseProcStatCpu(content).Should().BeNull();
+    }
+
+    [Fact]
+    public void ComputeCpuUsagePercent_UsesIdleDeltaOverTotalDelta()
+    {
+        var first = new CpuSample(Idle: 800, Total: 1000);
+        var second = new CpuSample(Idle: 1600, Total: 2000);
+
+        // idleDelta=800, totalDelta=1000 -> (1 - 0.8) * 100 = 20%
+        SystemMetricsCollector.ComputeCpuUsagePercent(first, second).Should().BeApproximately(20.0, 0.001);
+    }
+
+    [Fact]
+    public void ComputeCpuUsagePercent_ReturnsZero_WhenNoTimePassed()
+    {
+        var sample = new CpuSample(Idle: 800, Total: 1000);
+
+        SystemMetricsCollector.ComputeCpuUsagePercent(sample, sample).Should().Be(0.0);
+    }
+
+    // ---- Memory (/proc/meminfo) ------------------------------------------
+
+    [Fact]
+    public void ParseMemInfo_ComputesBytesFromTotalAndAvailable()
+    {
+        const string content =
+            "MemTotal:        8038600 kB\n" +
+            "MemFree:         1000000 kB\n" +
+            "MemAvailable:    4019300 kB\n" +
+            "Buffers:          200000 kB\n";
+
+        var parsed = SystemMetricsCollector.ParseMemInfo(content);
+
+        parsed.Should().NotBeNull();
+        parsed!.Value.totalBytes.Should().Be(8038600L * 1024);
+        parsed.Value.availableBytes.Should().Be(4019300L * 1024);
+        // used = total - available => 50% utilisation
+        var used = parsed.Value.totalBytes - parsed.Value.availableBytes;
+        ((double)used / parsed.Value.totalBytes * 100.0).Should().BeApproximately(50.0, 0.01);
+    }
+
+    [Fact]
+    public void ParseMemInfo_ReturnsNull_WhenAvailableMissing()
+    {
+        const string content = "MemTotal:        8038600 kB\nMemFree:  1000000 kB\n";
+
+        SystemMetricsCollector.ParseMemInfo(content).Should().BeNull();
+    }
+
+    // ---- Uptime (/proc/uptime) -------------------------------------------
+
+    [Theory]
+    [InlineData("12345.67 6789.01\n", 12345)]
+    [InlineData("0.50 0.50", 0)]
+    [InlineData("90061.99 1.0", 90061)]
+    public void ParseUptime_ReadsFirstFieldAsSeconds(string content, long expected)
+    {
+        SystemMetricsCollector.ParseUptime(content).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseUptime_ReturnsNull_WhenUnparseable()
+    {
+        SystemMetricsCollector.ParseUptime("not-a-number\n").Should().BeNull();
+    }
+
+    // ---- Container count (cross-platform via mocked Docker) ---------------
+
+    [Fact]
+    public async Task CollectMetricsAsync_IncludesRunningContainerCount()
+    {
+        _containerManager.GetRunningContainersAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<ContainerStatus>
+            {
+                new("a", "web", "nginx", "running", DateTime.UtcNow),
+                new("b", "db", "postgres", "running", DateTime.UtcNow),
+            });
+
+        var collector = new SystemMetricsCollector(_logger, _containerManager);
+
+        var metrics = await collector.CollectMetricsAsync();
+
+        metrics.RunningContainers.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CollectMetricsAsync_ReportsZeroContainers_WhenDockerUnavailable()
+    {
+        _containerManager.GetRunningContainersAsync(Arg.Any<CancellationToken>())
+            .Returns<List<ContainerStatus>>(_ => throw new InvalidOperationException("docker down"));
+
+        var collector = new SystemMetricsCollector(_logger, _containerManager);
+
+        var metrics = await collector.CollectMetricsAsync();
+
+        // A Docker failure must never crash metrics collection / the heartbeat loop.
+        metrics.RunningContainers.Should().Be(0);
+    }
+}

--- a/tests/SignalBeam.EdgeAgent.Tests.Unit/Security/CsrGeneratorTests.cs
+++ b/tests/SignalBeam.EdgeAgent.Tests.Unit/Security/CsrGeneratorTests.cs
@@ -1,0 +1,37 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using SignalBeam.EdgeAgent.Infrastructure.Security;
+
+namespace SignalBeam.EdgeAgent.Tests.Unit.Security;
+
+public class CsrGeneratorTests
+{
+    [Fact]
+    public void GenerateCsr_ProducesLoadableCsr_WithSubjectAndMatchingKey()
+    {
+        var generator = new CsrGenerator();
+
+        var (csrPem, privateKeyPem) = generator.GenerateCsr("CN=device-xyz, O=SignalBeam");
+
+        // The CSR is a valid PKCS#10 request carrying the expected subject.
+        var request = CertificateRequest.LoadSigningRequestPem(csrPem, HashAlgorithmName.SHA256);
+        request.SubjectName.Name.Should().Contain("device-xyz");
+
+        // The returned private key matches the CSR's public key.
+        using var privateKey = RSA.Create();
+        privateKey.ImportFromPem(privateKeyPem);
+        request.PublicKey.GetRSAPublicKey()!.ExportSubjectPublicKeyInfo()
+            .Should().Equal(privateKey.ExportSubjectPublicKeyInfo());
+    }
+
+    [Fact]
+    public void GenerateCsr_ProducesDistinctKeysPerCall()
+    {
+        var generator = new CsrGenerator();
+
+        var (_, key1) = generator.GenerateCsr("CN=a");
+        var (_, key2) = generator.GenerateCsr("CN=a");
+
+        key1.Should().NotBe(key2);
+    }
+}


### PR DESCRIPTION
Phase 0 substrate for the AI-Native Edge Platform epic (#370): make the EdgeAgent able to onboard end-to-end and report real host metrics, so a physical device (#371) can come online without manual key handling.

Closes #279
Closes #280

## #280 — Real system metrics
`SystemMetricsCollector` now reports host-level values instead of agent-process ones:
- **CPU** — two-sample delta from `/proc/stat` aggregate line (all cores)
- **Memory** — `/proc/meminfo` `MemTotal − MemAvailable` (real used bytes + %)
- **Uptime** — `/proc/uptime` since boot (`Environment.TickCount64` fallback)
- **Disk** — configurable mount via `Agent:MonitoredDiskPath` (default `/`)
- **Containers** — folded in via `IContainerManager` with a 5s timeout
- Linux primary, degraded Windows/macOS fallback, never throws (heartbeat can't be blocked)
- Metrics are now actually **published to NATS** (`signalbeam.telemetry.metrics.{deviceId}` → TelemetryProcessor), which was wired but never called

## #279 — Self-registration & key lifecycle (all 7 ACs)
- **AC1** one-time `claim-key` endpoint — token-authenticated, device-bound via `Device.KeyClaimedAt`; fixes the broken key delivery (status poll returned `ApiKey: null`)
- **AC2** `RegistrationPollingService` auto-polls for approval, then auto-claims and starts the loops
- **AC3** auto key rotation before expiry (`KeyLifecycleService` + `/rotate-key`)
- **AC4** device-generated CSR mTLS provisioning (private key never leaves the device; `request-cert` CLI + cloud `sign-csr`)
- **AC5** cert renewal (pre-existing service, now wired with real cert data)
- **AC6** `RegisterCommand` uses DI; `--cloud-url` now actually applies
- **AC7** auto-approve registration tokens for zero-touch onboarding

The registration handshake (register / registration-status / claim-key) is now reachable without an API key (a brand-new device has none), allowlisted in `DeviceAuthenticationMiddleware` by strict segment+GUID matching and authorized in-handler via the registration token.

EF migrations: `AddDeviceKeyClaimedAt`, `AddRegistrationTokenAutoApprove`.

## Security review fixes (applied in this PR)
- rotate-key object-level authorization (was an IDOR/BOLA)
- claim rejects revoked/expired tokens; single atomic save
- sign-csr clamps validity ≤365d; middleware allowlist hardened; agent clears the token after claim

## Test plan
- ✅ Release build clean (0/0); `dotnet format` clean; no pending migrations
- ✅ Unit tests: EdgeAgent 54, DeviceManager 29, Domain 117, Shared 39 (+full solution suites)
- ✅ Crypto round-trip test: CSR → CA sign → chains to CA, public key matches device key, clientAuth EKU
- ✅ Updated 2 integration tests to the new public-handshake contract
- ✅ Reviewer PASS (after fixes), Verifier PASS (14/14 ACs)

## Notes (non-blocking, follow-ups)
- ⚠️ The DeviceManager **integration suite is broken on `main`** independent of this PR (28 pre-existing failures, `RedirectHandler` errors across Tags/Groups/Bulk/etc.). This PR is net-zero there. Worth a separate tracking issue.
- 🔒 Hardening: token-less anonymous registration is still permitted (fine for the dogfood flow since the agent always sends a token). Consider requiring a valid registration token for unauthenticated registration as a follow-up.
- 📝 Docs to refresh via `/docs`: device-registration, device-authentication, edge-agent README, domain-model, + new device-manager API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)