### PR TITLE
document the Azure Container Apps deployment path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,9 +106,13 @@ dotnet ef database update
 cd web && npm install && npm run dev
 cd web && npm test && npm run lint
 
-# Helm
-helm install signalbeam-infra deploy/charts/signalbeam-infrastructure -n signalbeam --create-namespace
-helm install signalbeam deploy/charts/signalbeam-platform -n signalbeam
+# Helm (one chart per service under deploy/charts/)
+for c in device-manager bundle-orchestrator telemetry-processor identity-manager api-gateway web; do
+  helm upgrade --install "$c" "deploy/charts/$c" -n signalbeam --create-namespace
+done
+
+# Azure Container Apps (lean ~$20/mo path) — see infra/terragrunt/dev/aca/README.md
+cd infra/terragrunt/dev && terragrunt run --all apply --working-dir ./aca
 ```
 
 ## Code Quality

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ dotnet run
 - [Code Style](docs/development/code-style.md) - Coding conventions
 
 ### Operations
+- [Azure Infrastructure](infra/README.md) - Terraform/Terragrunt for AKS and the lean Azure Container Apps path
+- [Container Apps Deployment](infra/terragrunt/dev/aca/README.md) - Lean ~$20/mo dogfood control plane on ACA
 - [Deployment Guide](docs/operations/deployment.md) - Production deployment
 - [Monitoring](docs/operations/monitoring.md) - Observability and metrics
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,11 @@ Welcome to the SignalBeam Edge documentation! This directory contains guides, ar
 - **[Authentication Architecture](./architecture/authentication-architecture.md)** - Deep dive into authentication flows, JWT validation, and multi-tenancy
 - **[Docker Requirements](./docker-requirements.md)** - Container runtime requirements
 
+## Infrastructure & Deployment
+
+- **[Azure Infrastructure](../infra/README.md)** - Terraform/Terragrunt modules for the AKS path and the lean Azure Container Apps path
+- **[Container Apps Deployment](../infra/terragrunt/dev/aca/README.md)** - Lean ~$20/mo dogfood control plane on ACA (scale-to-zero, KV-reference secrets)
+
 ## Development
 
 - **[Development Setup](./development/)** - Local development environment setup

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -418,7 +418,7 @@ cd web
 npm run dev
 ```
 
-### Production (Kubernetes)
+### Production (Kubernetes / AKS)
 
 ```bash
 # 1. Deploy infrastructure chart
@@ -430,6 +430,30 @@ helm install signalbeam deploy/charts/signalbeam-platform
 # 3. Verify deployment
 kubectl get pods -n signalbeam
 ```
+
+### Production (Azure Container Apps — lean/dogfood, ~$20/mo)
+
+An alternative, cost-optimized path for a single dogfood device. Stateless
+services scale to zero; NATS is the only always-on component. Valkey and Zitadel
+are omitted (in-process cache + API-key auth), and secrets use Key Vault
+references via a managed identity.
+
+```bash
+# Base platform (resource-group, networking, key-vault, postgresql, monitoring, managed-identity)
+cd infra/terragrunt/dev
+terragrunt run --all apply --queue-include-dir ./resource-group --queue-include-dir ./networking \
+  --queue-include-dir ./managed-identity --queue-include-dir ./monitoring \
+  --queue-include-dir ./key-vault --queue-include-dir ./postgresql
+
+# ACA stack (environment, secrets, nats, apigateway + 4 services)
+terragrunt run --all apply --working-dir ./aca
+
+# Set the GHCR pull token out-of-band, then fetch the public gateway URL
+az keyvault secret set --vault-name sb-kv-dev-weu --name ghcr-pat --value <PAT>
+terragrunt output --working-dir ./aca/apigateway fqdn
+```
+
+See [`infra/terragrunt/dev/aca/README.md`](../infra/terragrunt/dev/aca/README.md) for the full runbook.
 
 ## Monitoring & Observability
 

--- a/docs/architecture/technical-architecture.md
+++ b/docs/architecture/technical-architecture.md
@@ -714,9 +714,71 @@ graph TB
     style Tempo fill:#f8bbd0
 ```
 
+### Production Deployment (Azure Container Apps — lean/dogfood)
+
+For a single dogfood device or cost-sensitive deployments, the control plane can
+run on **Azure Container Apps (ACA) Consumption** instead of AKS — targeting
+**~$20/mo**. Stateless services scale to zero; NATS is the only always-on
+component. This is an additive path (the AKS modules remain available); it trades
+the in-cluster observability stack and multi-replica HA for cost and operational
+simplicity. See [`infra/terragrunt/dev/aca/README.md`](../../infra/terragrunt/dev/aca/README.md).
+
+```mermaid
+graph TB
+    Agent([EdgeAgent / Internet])
+
+    subgraph ACA["Azure Container Apps Environment (Consumption)"]
+        GW[ApiGateway / YARP<br/>External ingress<br/>scale 0 to 1]
+        DM[DeviceManager<br/>internal · 0 to 1]
+        BO[BundleOrchestrator<br/>internal · 0 to 1]
+        TP[TelemetryProcessor<br/>internal · 0 to 1]
+        IM[IdentityManager<br/>internal · 0 to 1]
+        NATS[NATS + JetStream<br/>internal TCP · min 1]
+    end
+
+    subgraph Azure["Azure Managed Services"]
+        PSQL[(PostgreSQL<br/>Flexible Server<br/>Burstable B1ms)]
+        KV[Key Vault<br/>secret references]
+        LAW[Log Analytics]
+        FILES[Azure Files<br/>NATS persistence]
+    end
+
+    Agent -->|HTTPS| GW
+    GW -->|https internal| DM
+    GW -->|https internal| BO
+    GW -->|https internal| TP
+    GW -->|https internal| IM
+    DM & BO & TP & IM -->|NATS TCP| NATS
+    DM & BO & TP & IM -.->|Read/Write| PSQL
+    DM & BO & TP & IM -.->|secrets via MI| KV
+    NATS -.->|persist| FILES
+    GW -.->|logs| LAW
+
+    style GW fill:#e1f5ff
+    style DM fill:#c8e6c9
+    style BO fill:#c8e6c9
+    style TP fill:#c8e6c9
+    style IM fill:#c8e6c9
+    style NATS fill:#ffe0b2
+    style PSQL fill:#fff9c4
+    style KV fill:#fff9c4
+    style LAW fill:#f8bbd0
+    style FILES fill:#fff9c4
+```
+
+**Differences from the AKS path** (lean dogfood):
+- **Valkey omitted** — caching is in-process `IMemoryCache`; no standalone cache.
+- **Zitadel omitted** — device flows authenticate with API keys, not OIDC.
+- **No in-cluster Prometheus/Loki/Tempo** — logs go to the Azure Log Analytics workspace.
+- **Secrets as Key Vault references** resolved by a user-assigned managed identity (never written into the container app definitions or Terraform state).
+- **Images from private GHCR** via a PAT held in Key Vault (no ACR).
+- **mTLS deferred** — registration handshake uses API keys.
+
 **Infrastructure as Code**:
-- Terraform for cloud resources
-- Helm charts for Kubernetes deployments
+- Terraform for cloud resources (`infra/terraform/modules/`); ACA modules:
+  `container-app-environment`, `container-app`, `app-secrets`
+- Terragrunt for environment wiring (`infra/terragrunt/dev/`; ACA stack under `dev/aca/`)
+- Helm charts for Kubernetes (AKS) deployments
 - ArgoCD for GitOps
 
 ## Observability

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,0 +1,116 @@
+# Deployment Guide
+
+How to deploy the SignalBeam control plane to Azure. Two paths share the same base
+infrastructure and diverge at the compute layer.
+
+| Path | Compute | Cost | Use when |
+|------|---------|------|----------|
+| **AKS** | Kubernetes + Helm | ~$142/mo | Multi-replica HA, in-cluster observability, many devices |
+| **Azure Container Apps** | ACA Consumption | ~$20/mo | Single dogfood device, cost-sensitive, scale-to-zero |
+
+Both provision from `infra/`. Detailed runbooks: [`infra/README.md`](../../infra/README.md)
+(AKS) and [`infra/terragrunt/dev/aca/README.md`](../../infra/terragrunt/dev/aca/README.md) (ACA).
+
+## Prerequisites
+
+```bash
+brew install azure-cli terraform terragrunt
+az login
+az account set --subscription "<SUBSCRIPTION_ID>"
+```
+
+- Azure subscription with Owner or Contributor.
+- Set the subscription ID in `infra/terragrunt/dev/env.hcl`.
+- Bootstrap the remote state backend once: `./infra/scripts/bootstrap.sh`. This
+  creates `sb-tfstate-dev-weu` and a state storage account.
+
+## Base infrastructure (both paths)
+
+Phases 1–4 are identical: resource group, networking, monitoring, managed
+identity, Key Vault, Postgres, storage.
+
+```bash
+cd infra/terragrunt/dev
+terragrunt run --all apply \
+  --queue-include-dir ./resource-group --queue-include-dir ./networking \
+  --queue-include-dir ./monitoring --queue-include-dir ./managed-identity \
+  --queue-include-dir ./key-vault --queue-include-dir ./postgresql --queue-include-dir ./storage
+```
+
+Terragrunt resolves the dependency order. Postgres is private (VNet-only); its
+admin password is generated into Key Vault.
+
+## Path A — AKS
+
+```bash
+cd infra/terragrunt/dev
+terragrunt run --all apply          # provisions AKS + ingress + NATS + observability
+az aks get-credentials --resource-group sb-rg-dev-weu --name sb-aks-dev-weu
+
+# One chart per service under deploy/charts/
+for c in device-manager bundle-orchestrator telemetry-processor identity-manager api-gateway web; do
+  helm upgrade --install "$c" "deploy/charts/$c" -n signalbeam --create-namespace
+done
+kubectl get pods -n signalbeam
+```
+
+The public entry point is the NGINX ingress LoadBalancer IP; TLS is issued by
+cert-manager. See [`infra/README.md`](../../infra/README.md) for DNS, ingress, and
+the observability stack.
+
+## Path B — Azure Container Apps
+
+```bash
+cd infra/terragrunt/dev
+terragrunt run --all apply --working-dir ./aca   # environment, secrets, NATS, gateway + 4 services
+```
+
+Set the GHCR pull token out-of-band (it never enters Terraform state), then read
+the public gateway URL for the agent's `--cloud-url`:
+
+```bash
+az keyvault secret set --vault-name sb-kv-dev-weu --name ghcr-pat --value <PAT>
+terragrunt output --working-dir ./aca/apigateway fqdn
+```
+
+Images come from `ghcr.io/signalbeam-io/{service}:latest`; publish them before
+applying. The ACA path omits Valkey and Zitadel and routes logs to Log Analytics.
+
+## Database migrations
+
+Apply EF Core migrations against the deployed Postgres. The server is private —
+run from a VNet-connected host or temporarily allow your IP. The connection string
+is in Key Vault as `db-connection-signalbeam`.
+
+```bash
+dotnet ef database update --project src/DeviceManager/SignalBeam.DeviceManager.Infrastructure
+# repeat per service that owns schema
+```
+
+## Verify
+
+```bash
+# Postgres is private
+az postgres flexible-server show -g sb-rg-dev-weu -n sb-psql-dev-weu \
+  --query "network.publicNetworkAccess"          # → Disabled
+
+# Public registration endpoint reachable (substitute the gateway host)
+curl -i https://<gateway-fqdn>/api/devices
+```
+
+AKS adds `kubectl get pods -n signalbeam` and the ingress external IP. ACA exposes
+health at `/health/live` and `/health/ready` per app.
+
+## Teardown and cost control
+
+```bash
+# ACA: destroy compute between dogfood sessions (drops to ~$3–5/mo storage)
+terragrunt run --all destroy --working-dir ./aca
+
+# Full teardown
+cd infra/terragrunt/dev && terragrunt run --all destroy
+```
+
+Postgres can also be stopped overnight to halve its cost. Destroying the ACA stack
+removes the NATS JetStream Azure Files share — acceptable for a dogfood, where
+message data is transient.

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,0 +1,70 @@
+# Monitoring
+
+Observability differs by deployment path. AKS runs a self-hosted stack; ACA uses
+Azure Log Analytics.
+
+## Signals
+
+Every service emits the same three signals via OpenTelemetry (configured in
+`SignalBeam.ServiceDefaults`):
+
+- **Metrics** — RED metrics (rate, errors, duration) plus business counters
+  (devices registered, rollouts completed) at `/metrics`.
+- **Logs** — structured Serilog with `DeviceId`/`TenantId` fields.
+- **Traces** — distributed traces across the gateway and services.
+
+Health endpoints: `/health/live` (process up, no dependency checks) and
+`/health/ready` (dependencies reachable).
+
+## AKS path
+
+Telemetry flows through the OTEL Collector to backends, visualized in Grafana.
+
+```
+Services → OTEL Collector → Tempo (traces)
+                          → Prometheus (metrics)
+                          → Loki (logs)
+                          → Grafana (dashboards)
+```
+
+| Component | Namespace | Service |
+|-----------|-----------|---------|
+| OTEL Collector | `signalbeam` | `otel-collector.signalbeam:4317` |
+| Prometheus | `monitoring` | `kube-prometheus-stack-prometheus:9090` |
+| Grafana | `monitoring` | `kube-prometheus-stack-grafana:80` |
+| Loki | `monitoring` | `loki.monitoring:3100` |
+| Tempo | `monitoring` | `tempo.monitoring:3100` |
+| AlertManager | `monitoring` | `kube-prometheus-stack-alertmanager:9093` |
+
+```bash
+# Grafana (default datasources: Prometheus, Loki, Tempo)
+kubectl -n monitoring port-forward svc/kube-prometheus-stack-grafana 3000:80
+
+# Check the stack is healthy
+kubectl -n monitoring get pods
+```
+
+Retention: Loki and Tempo 7 days, Prometheus per its PVC. Microservice Helm charts
+define ServiceMonitors that Prometheus Operator discovers automatically.
+
+## ACA path
+
+ACA streams container logs to the Log Analytics workspace `sb-law-dev-weu`. There
+is no in-cluster Prometheus/Grafana — query logs and metrics with KQL.
+
+```bash
+# Tail recent logs for one app
+az monitor log-analytics query \
+  --workspace "$(az monitor log-analytics workspace show -g sb-rg-dev-weu -n sb-law-dev-weu --query customerId -o tsv)" \
+  --analytics-query 'ContainerAppConsoleLogs_CL | where ContainerAppName_s == "sb-ca-devicemanager-dev" | order by TimeGenerated desc | take 100'
+```
+
+Per-app revision status and replica health are visible in the Container Apps blade
+or via `az containerapp revision list`. Set an ingestion cap on the workspace to
+keep cost near the free tier.
+
+## Alerts
+
+Alert rules live with the AKS observability stack (`kube-prometheus-stack`
+AlertManager). The ACA path has no built-in alerting; wire Azure Monitor alerts on
+the Log Analytics workspace if needed.

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,7 +4,10 @@ Terraform + Terragrunt configuration for provisioning the SignalBeam Edge dev en
 
 ## Architecture
 
-17 Terraform modules wired together by Terragrunt with the following dependency graph:
+20 Terraform modules wired together by Terragrunt. There are **two deployment
+paths** that share the same base (Phases 1–4):
+
+**AKS path** (full stack, ~$142/mo):
 
 ```
 Phase 1: resource-group
@@ -17,12 +20,24 @@ Phase 7: loki, tempo  (depend on kube-prometheus-stack for monitoring namespace)
 Phase 8: otel-collector  (depends on loki + tempo + kube-prometheus-stack)
 ```
 
+**Azure Container Apps path** (lean/dogfood, ~$20/mo — replaces AKS phases 5–8):
+
+```
+Phase 1–4: (same base as above)
+Phase 5: aca/environment  (depends on networking[aca subnet] + monitoring)
+Phase 6: aca/secrets  (depends on key-vault + postgresql)
+Phase 7: aca/nats, aca/apigateway, aca/devicemanager, aca/bundleorchestrator,
+         aca/telemetryprocessor, aca/identitymanager  (depend on environment + secrets + managed-identity)
+```
+
+See [`terragrunt/dev/aca/README.md`](terragrunt/dev/aca/README.md) for the ACA runbook.
+
 ## Resources Provisioned
 
 | Module | Resources | Est. Cost |
 |--------|-----------|-----------|
 | resource-group | Resource group `sb-rg-dev-weu` | — |
-| networking | VNet, 3 subnets (AKS, PostgreSQL, Services), NSGs, private DNS zone | — |
+| networking | VNet, 4 subnets (AKS, PostgreSQL, Services, ACA), NSGs, private DNS zone | — |
 | monitoring | Log Analytics workspace, ContainerInsights solution | $0 (5GB free) |
 | container-registry | ACR Basic (`sbacrdevweu`) | ~$5/mo |
 | managed-identity | User-assigned identity for workload identity | — |
@@ -38,7 +53,21 @@ Phase 8: otel-collector  (depends on loki + tempo + kube-prometheus-stack)
 | loki | Log aggregation, single-binary mode (10Gi) | ~$0 (runs on AKS) |
 | tempo | Distributed tracing backend (10Gi) | ~$0 (runs on AKS) |
 | otel-collector | OpenTelemetry Collector (2 replicas), routes to Tempo/Prometheus/Loki | ~$0 (runs on AKS) |
-| **Total** | | **~$142/mo** |
+| **Total (AKS path)** | | **~$142/mo** |
+
+### Azure Container Apps path (lean/dogfood)
+
+Replaces the AKS phases 5–8 with a Consumption-based Container Apps stack. Shares
+the base modules (resource-group, networking, monitoring, managed-identity,
+key-vault, postgresql). Valkey, Zitadel, and ACR are omitted.
+
+| Module | Resources | Est. Cost |
+|--------|-----------|-----------|
+| container-app-environment | ACA env (Consumption, public LB) + storage account + Azure Files share for NATS | ~$1–3/mo (Files) |
+| app-secrets | Key Vault secrets: DB connection string + GHCR PAT placeholder | — |
+| container-app (×6) | ApiGateway (external) + DeviceManager, BundleOrchestrator, TelemetryProcessor, IdentityManager (internal, scale-to-zero), NATS (internal TCP, min 1) | NATS ~$5–7/mo; rest ~$0 (free grant) |
+| postgresql (shared base) | Flexible Server B1ms | ~$13/mo |
+| **Total (ACA path)** | | **~$20/mo** |
 
 ## Prerequisites
 
@@ -231,6 +260,13 @@ terragrunt run --all destroy
 - **Calico network policies** in AKS for namespace isolation
 - **Auto-generated secrets** — PostgreSQL password + Zitadel key stored in Key Vault
 
+**ACA path additionally:**
+- **Delegated ACA subnet** (`snet-aca`, /27) with `Microsoft.App/environments` delegation; Postgres NSG explicitly allows it on 5432
+- **Key Vault references** — container apps read secrets via the managed identity (`Key Vault Secrets User`); values never enter the app definitions
+- **NATS Azure Files account** denies public access, restricted to the ACA subnet via a `Microsoft.Storage` service endpoint
+- **Private GHCR** — pull token held in Key Vault (`ghcr-pat`), set out-of-band so it never enters Terraform state
+- See [`terragrunt/dev/aca/README.md`](terragrunt/dev/aca/README.md#terraform-state-contains-sensitive-material) for state-handling guidance
+
 ## File Structure
 
 ```
@@ -254,7 +290,10 @@ infra/
 │   ├── kube-prometheus-stack/           # Prometheus + Grafana + AlertManager
 │   ├── loki/                            # Log aggregation
 │   ├── tempo/                           # Distributed tracing
-│   └── otel-collector/                  # OpenTelemetry Collector
+│   ├── otel-collector/                  # OpenTelemetry Collector
+│   ├── container-app-environment/       # ACA env + Azure Files for NATS (ACA path)
+│   ├── container-app/                   # Reusable Container App (ACA path)
+│   └── app-secrets/                     # KV secrets for ACA (ACA path)
 └── terragrunt/
     ├── terragrunt.hcl                   # Root config: backend, provider, inputs
     └── dev/
@@ -275,7 +314,16 @@ infra/
         ├── kube-prometheus-stack/terragrunt.hcl
         ├── loki/terragrunt.hcl
         ├── tempo/terragrunt.hcl
-        └── otel-collector/terragrunt.hcl
+        ├── otel-collector/terragrunt.hcl
+        └── aca/                         # Container Apps path (alternative to AKS)
+            ├── environment/terragrunt.hcl
+            ├── secrets/terragrunt.hcl
+            ├── nats/terragrunt.hcl
+            ├── apigateway/terragrunt.hcl
+            ├── devicemanager/terragrunt.hcl
+            ├── bundleorchestrator/terragrunt.hcl
+            ├── telemetryprocessor/terragrunt.hcl
+            └── identitymanager/terragrunt.hcl
 ```
 
 ## NATS Architecture


### PR DESCRIPTION
Documentation follow-up to #376 (the ACA deployment, merged). These commits landed on the feature branch after the merge, so they need their own PR.

## What's included
- **`infra/README.md`** — ACA dependency graph, lean ~$20/mo cost table, the three new modules in the file tree + `dev/aca/` units, ACA-specific security notes.
- **`docs/architecture/technical-architecture.md`** — "Production Deployment (Azure Container Apps)" section with a validated mermaid diagram and a differences-from-AKS list; IaC note updated.
- **`docs/architecture.md`** — ACA deployment block with the real `terragrunt` apply / GHCR / FQDN commands.
- **`docs/operations/deployment.md`** (new) — operator entry point: path selection (AKS vs ACA), prerequisites, shared base apply, per-path commands, migrations, verify, teardown.
- **`docs/operations/monitoring.md`** (new) — signals, the AKS Grafana/Prometheus/Loki/Tempo stack, and the ACA Log Analytics path.
- **`README.md` / `docs/README.md`** — links to the infra and ACA runbooks (resolves the previously-dangling Operations links).
- **`CLAUDE.md`** — replaced the non-existent `signalbeam-infrastructure`/`signalbeam-platform` umbrella charts with the actual per-service charts; added the ACA apply command.

## Verified against the repo
- Helm commands use the real per-service charts under `deploy/charts/` (`device-manager`, `api-gateway`, …).
- The mermaid diagram validates (`valid: true`).
- All referenced paths (modules, EF project) exist.

Docs-only — no code or infrastructure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)