### PR TITLE
upgrade to .NET 10, Aspire 13, EF Core 10, Wolverine 5

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -12,7 +12,7 @@ Code reviewer for SignalBeam Edge — the deep PR-level quality gate.
 ## Context
 
 SignalBeam Edge is a fleet management platform for edge devices using:
-- .NET 9 with hexagonal architecture (Domain / Application / Infrastructure / Host layers)
+- .NET 10 with hexagonal architecture (Domain / Application / Infrastructure / Host layers)
 - CQRS with WolverineFx — commands mutate state, queries read
 - Result pattern — handlers return `Result<T>`, no exceptions for business logic
 - EF Core + PostgreSQL/TimescaleDB, Dapper for read-optimized queries

--- a/.github/workflows/build-edge-agent.yml
+++ b/.github/workflows/build-edge-agent.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '9.0.x'
+  DOTNET_VERSION: '10.0.x'
   PACKAGE_NAME: signalbeam-agent
 
 jobs:

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore dependencies
         run: dotnet restore src/SignalBeam.sln

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore dependencies
         run: dotnet restore src/SignalBeam.sln
@@ -68,7 +68,7 @@ jobs:
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Check formatting
         run: dotnet format src/SignalBeam.sln --verify-no-changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,171 @@
+name: Deploy to Azure Container Apps
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'src/SignalBeam.sln'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-aca-dev
+  cancel-in-progress: false
+
+# OIDC federation to Azure AD: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure
+# Prereqs (one-time):
+#   - Azure AD app + federated credential on this repo/branch (set AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID secrets).
+#   - The deployer service principal needs Contributor on each container app so `az containerapp update` can swap the image tag.
+#   - Container Apps (sb-ca-*-dev) are provisioned by Terragrunt (infra/terragrunt/dev/aca) and already hold the
+#     ghcr-pat registry secret, so they can pull private images from ghcr.io/signalbeam-io.
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
+env:
+  RESOURCE_GROUP: sb-rg-dev-weu
+  REGISTRY: ghcr.io
+  IMAGE_OWNER: signalbeam-io
+
+jobs:
+  deploy:
+    name: Deploy ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    environment: dev
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: device-manager
+            app: sb-ca-devicemanager-dev
+            image: devicemanager
+            dockerfile: ./src/DeviceManager/Dockerfile
+          - service: bundle-orchestrator
+            app: sb-ca-bundleorchestrator-dev
+            image: bundleorchestrator
+            dockerfile: ./src/BundleOrchestrator/Dockerfile
+          - service: telemetry-processor
+            app: sb-ca-telemetryprocessor-dev
+            image: telemetryprocessor
+            dockerfile: ./src/TelemetryProcessor/Dockerfile
+          - service: identity-manager
+            app: sb-ca-identitymanager-dev
+            image: identitymanager
+            dockerfile: ./src/IdentityManager/Dockerfile
+          - service: api-gateway
+            app: sb-ca-apigateway-dev
+            image: apigateway
+            dockerfile: ./src/SignalBeam.ApiGateway/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set image tag
+        id: meta
+        run: echo "tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image }}:${{ steps.meta.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image }}:latest
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+      - name: Update Container App
+        run: |
+          az containerapp update \
+            --name "${{ matrix.app }}" \
+            --resource-group "$RESOURCE_GROUP" \
+            --image "$REGISTRY/$IMAGE_OWNER/${{ matrix.image }}:${{ steps.meta.outputs.tag }}" \
+            --output none
+
+      - name: Wait for new revision to run
+        run: |
+          # Single-revision mode — the newest revision by createdTime is the one we just deployed.
+          rev=$(az containerapp revision list \
+            --name "${{ matrix.app }}" \
+            --resource-group "$RESOURCE_GROUP" \
+            --query "sort_by([], &properties.createdTime)[-1].name" -o tsv)
+          echo "Waiting for revision $rev to reach runningState=Running"
+          for attempt in $(seq 1 30); do
+            state=$(az containerapp revision show \
+              --name "${{ matrix.app }}" \
+              --resource-group "$RESOURCE_GROUP" \
+              --revision "$rev" \
+              --query properties.runningState -o tsv 2>/dev/null || echo "Unknown")
+            if [ "$state" = "Running" ]; then
+              echo "Revision ready after ${attempt} attempt(s)."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: state=$state, retrying in 5s…"
+            sleep 5
+          done
+          echo "Revision $rev did not reach Running within 150s." >&2
+          exit 1
+
+  smoke-test:
+    name: Smoke test API gateway
+    needs: deploy
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve API gateway FQDN
+        id: app
+        run: |
+          fqdn=$(az containerapp show \
+            --name sb-ca-apigateway-dev \
+            --resource-group "$RESOURCE_GROUP" \
+            --query properties.configuration.ingress.fqdn -o tsv)
+          echo "fqdn=$fqdn" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test /health/live
+        # /health/live is the liveness endpoint mapped by ServiceDefaults — confirms the app
+        # process is up without running the DB/NATS readiness checks that /health triggers.
+        run: |
+          url="https://${{ steps.app.outputs.fqdn }}/health/live"
+          echo "Probing $url"
+          for attempt in $(seq 1 30); do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "$url" || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "Healthy after ${attempt} attempt(s)."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: got $code, retrying in 5s…"
+            sleep 5
+          done
+          echo "Smoke test failed: /alive did not return 200 within 150s." >&2
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ SignalBeam Edge is a fleet management platform for edge devices (Raspberry Pis, 
 
 ## Tech Stack
 
-- **Backend:** .NET 9, C# 13, hexagonal architecture
+- **Backend:** .NET 10, C# 14, hexagonal architecture
 - **CQRS/Messaging:** WolverineFx, NATS with JetStream
 - **Data:** EF Core + PostgreSQL/TimescaleDB, Dapper for read queries
 - **Cache:** Valkey (Redis-compatible, uses StackExchange.Redis client)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,77 +2,82 @@
   <PropertyGroup>
     <!-- Enable Central Package Management -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Pin transitive dependencies to patched versions without forcing a direct
+         reference in every project (keeps the Domain layer dependency-free). -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-  <ItemGroup Label="NuGet audit suppressions">
-    <!--
-      CVE-2026-42191 / GHSA-4625-4j76-fww9 — OpenTelemetry.Exporter.OpenTelemetryProtocol.
-      The vulnerable code path is the OTLP exporter's opt-in disk-retry feature falling back
-      to the shared temp directory. SignalBeam uses the OTLP exporter only with default config
-      (UseOtlpExporter/AddOtlpExporter) and never enables disk retry / persistent storage, so
-      this code path is not reachable.
-      The only patched version (1.15.3) requires System.Diagnostics.DiagnosticSource >= 10.0.0,
-      which WolverineFx 3.7.0 forbids (< 10.0.0) — there is no net9-compatible patched version.
-      Tracked for a real upgrade (Wolverine 4.x + OTel 1.15.x) as a follow-up.
-    -->
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-4625-4j76-fww9" />
+  <ItemGroup Label="Security transitive pins">
+    <!-- Force OpenTelemetry.Api to the patched version (GHSA-g94r-2vxg-569j). -->
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <!-- Pin transitive ASP.NET Core / crypto packages (pulled via Microsoft.Identity.Web)
+         to the latest 10.0.x servicing release to clear NU1903/NU1904 audit advisories
+         (GHSA-9mv3-2cwr-p262, GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf). -->
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <!-- Pin MessagePack (pulled transitively by the Aspire AppHost / dashboard) to the
+         latest patched 2.5.x release to clear GHSA-hv8m-jj95-wg3x without the 3.x major bump. -->
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
   </ItemGroup>
   <ItemGroup Label="Messaging and CQRS">
-    <PackageVersion Include="WolverineFx" Version="3.7.0" />
-    <PackageVersion Include="WolverineFx.Http" Version="3.7.0" />
+    <PackageVersion Include="WolverineFx" Version="5.27.0" />
+    <PackageVersion Include="WolverineFx.Http" Version="5.27.0" />
   </ItemGroup>
   <ItemGroup Label="Data Access">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
-    <PackageVersion Include="Dapper" Version="2.1.44" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageVersion Include="Dapper" Version="2.1.66" />
   </ItemGroup>
   <ItemGroup Label="Cloud-Native Integrations">
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.2" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageVersion Include="NATS.Client.Core" Version="2.7.2" />
     <PackageVersion Include="NATS.Client.JetStream" Version="2.7.2" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.16" />
-    <PackageVersion Include="Azure.Identity" Version="1.13.1" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.11.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.18.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
   </ItemGroup>
   <ItemGroup Label="Container Management">
-    <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+    <!-- Docker.DotNet.Enhanced is the maintained fork Testcontainers 4.11 depends on.
+         The EdgeAgent uses the same fork (namespace-compatible) so the test project
+         doesn't end up with two conflicting Docker.DotNet assemblies. -->
+    <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.131.1" />
   </ItemGroup>
   <ItemGroup Label="Hosting and Configuration">
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
   <ItemGroup Label="System Monitoring">
-    <PackageVersion Include="System.Management" Version="9.0.0" />
+    <PackageVersion Include="System.Management" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup Label="Authentication and Authorization">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="4.1.1" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
   </ItemGroup>
   <ItemGroup Label="API Documentation">
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="1.2.42" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.8.5" />
   </ItemGroup>
   <ItemGroup Label="API Gateway">
-    <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.1.0" />
+    <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.4.0" />
   </ItemGroup>
   <ItemGroup Label="Observability">
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.10.0-beta.1" />
-    <PackageVersion Include="Serilog" Version="4.1.0" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.12.0-beta.1" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
@@ -88,43 +93,43 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
   </ItemGroup>
   <ItemGroup Label="Serialization">
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup Label="Health Checks">
-    <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
-    <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
-    <PackageVersion Include="AspNetCore.HealthChecks.AzureBlobStorage" Version="8.0.1" />
+    <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.AzureBlobStorage" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup Label=".NET Aspire">
-    <PackageVersion Include="Aspire.Hosting" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.1.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="9.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="9.5.2" />
+    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.2.1" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="13.2.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
-    <PackageVersion Include="Testcontainers" Version="4.0.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup Label="Code Analyzers">
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.9" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.4.0.108396" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The Quick Start guide includes:
 
 ### Prerequisites
 
-- **.NET 9 SDK**
+- **.NET 10 SDK**
 - **Docker Desktop** (for infrastructure services)
 - **Node.js 20+** (for frontend)
 - **.NET Aspire workload**:
@@ -175,8 +175,8 @@ dotnet run
 
 ## Technology Stack
 
-### Backend (.NET 9)
-- **Framework**: .NET 9, C# 13, ASP.NET Core Minimal APIs
+### Backend (.NET 10)
+- **Framework**: .NET 10, C# 14, ASP.NET Core Minimal APIs
 - **Architecture**: Hexagonal (Ports & Adapters) with CQRS
 - **Database**: Entity Framework Core + PostgreSQL + TimescaleDB
 - **Messaging**: NATS with JetStream
@@ -285,7 +285,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ## Acknowledgments
 
-- Built with [.NET 9](https://dot.net) and [.NET Aspire](https://learn.microsoft.com/aspire)
+- Built with [.NET 10](https://dot.net) and [.NET Aspire](https://learn.microsoft.com/aspire)
 - UI components from [shadcn/ui](https://ui.shadcn.com/)
 - Inspired by the need for simple, effective edge device management
 

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -349,7 +349,7 @@ The domain layer has zero external dependencies - pure business logic.
 ### 7. Nullable Reference Types
 Enabled throughout for compile-time null safety.
 
-### 8. C# 13 Features
+### 8. C# 14 Features
 - Record types for value objects and events
 - Record structs for IDs
 - Init-only properties

--- a/docs/architecture/technical-architecture.md
+++ b/docs/architecture/technical-architecture.md
@@ -65,11 +65,11 @@ C4Container
     System_Boundary(signalbeam, "SignalBeam Edge Platform") {
         Container(webUI, "Web UI", "React, TypeScript", "Provides fleet management interface via web browser")
 
-        Container(deviceManager, "DeviceManager Service", ".NET 9, ASP.NET Core", "Manages device registration, grouping, and health monitoring")
+        Container(deviceManager, "DeviceManager Service", ".NET 10, ASP.NET Core", "Manages device registration, grouping, and health monitoring")
 
-        Container(bundleOrchestrator, "BundleOrchestrator Service", ".NET 9, ASP.NET Core", "Manages application bundles, versions, and rollout orchestration")
+        Container(bundleOrchestrator, "BundleOrchestrator Service", ".NET 10, ASP.NET Core", "Manages application bundles, versions, and rollout orchestration")
 
-        Container(telemetryProcessor, "TelemetryProcessor Service", ".NET 9, ASP.NET Core", "Processes device metrics and telemetry data")
+        Container(telemetryProcessor, "TelemetryProcessor Service", ".NET 10, ASP.NET Core", "Processes device metrics and telemetry data")
 
         ContainerDb(database, "Database", "PostgreSQL + TimescaleDB", "Stores device state, bundles, rollout status, and time-series metrics")
 
@@ -81,7 +81,7 @@ C4Container
     }
 
     System_Ext(edgeDevice, "Edge Device", "Raspberry Pi, mini-PC running Docker/Podman")
-    Container_Ext(edgeAgent, "Edge Agent", ".NET 9 Console App", "Runs on device, reconciles container state")
+    Container_Ext(edgeAgent, "Edge Agent", ".NET 10 Console App", "Runs on device, reconciles container state")
 
     Rel(fleetManager, webUI, "Uses", "HTTPS")
 

--- a/docs/aspire-setup.md
+++ b/docs/aspire-setup.md
@@ -4,7 +4,7 @@ This guide shows how to run the entire SignalBeam platform using .NET Aspire for
 
 ## Prerequisites
 
-- .NET 9.0 SDK
+- .NET 10.0 SDK
 - Docker Desktop (running)
 - .NET Aspire workload: `dotnet workload install aspire`
 

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -16,11 +16,11 @@ This guide will help you set up SignalBeam Edge for local development. We recomm
 
 ### Required Software
 
-1. **.NET 9 SDK** ([download](https://dotnet.microsoft.com/download/dotnet/9.0))
+1. **.NET 10 SDK** ([download](https://dotnet.microsoft.com/download/dotnet/10.0))
    ```bash
    # Verify installation
    dotnet --version
-   # Should show: 9.0.x
+   # Should show: 10.0.x
    ```
 
 2. **.NET Aspire Workload**
@@ -265,7 +265,7 @@ Example `launch.json`:
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
-      "program": "${workspaceFolder}/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/bin/Debug/net9.0/SignalBeam.BundleOrchestrator.Host.dll",
+      "program": "${workspaceFolder}/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/bin/Debug/net10.0/SignalBeam.BundleOrchestrator.Host.dll",
       "args": [],
       "cwd": "${workspaceFolder}/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host",
       "stopAtEntry": false,

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -76,6 +76,23 @@ terragrunt output --working-dir ./aca/apigateway fqdn
 Images come from `ghcr.io/signalbeam-io/{service}:latest`; publish them before
 applying. The ACA path omits Valkey and Zitadel and routes logs to Log Analytics.
 
+### Continuous deployment (GitHub Actions)
+
+Once the Container Apps exist, `.github/workflows/deploy.yml` handles redeploys on
+every push to `main` (or via `workflow_dispatch`). For each service it builds and
+pushes the image to GHCR, runs `az containerapp update` to the new `${GITHUB_SHA::7}`
+tag, waits for the revision to reach `Running`, then smoke-tests the gateway's
+`/health/live`. It authenticates to Azure with OIDC — no stored credentials.
+
+One-time setup:
+
+- Create an Azure AD app with a federated credential for this repo/branch and set
+  the `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` repo secrets.
+- Grant the deployer service principal **Contributor** on each `sb-ca-*-dev` app so
+  it can swap the image tag.
+- The apps already hold the `ghcr-pat` registry secret (set above), so they can pull
+  the private images.
+
 ## Database migrations
 
 Apply EF Core migrations against the deployed Postgres. The server is private —

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -90,7 +90,7 @@ See `RUNNING_WITH_ASPIRE.md` for configuration details.
 
 ### Prerequisites
 
-- .NET 9 SDK
+- .NET 10 SDK
 - Docker Desktop
 - Aspire workload
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ Get up and running with SignalBeam in under 5 minutes with **fully automated** Z
 
 ## Prerequisites
 
-- .NET 9 SDK
+- .NET 10 SDK
 - Docker Desktop
 - Node.js 20+
 - jq (for config scripts): `brew install jq` (macOS) or `apt install jq` (Linux)
@@ -204,7 +204,7 @@ The setup will run again automatically and create new IDs.
 
 ### ⚙️ One-Time Setup (Per Developer Machine)
 
-- Install .NET 9 SDK
+- Install .NET 10 SDK
 - Install Docker Desktop
 - Install Node.js
 - Run `npm install` in `web/` directory

--- a/docs/services/edge-agent/INSTALL.md
+++ b/docs/services/edge-agent/INSTALL.md
@@ -278,7 +278,7 @@ For developers or custom deployments:
 
 #### Prerequisites
 
-- .NET 9.0 SDK
+- .NET 10.0 SDK
 - Docker (optional, for containerized apps)
 
 #### Build Steps

--- a/docs/services/edge-agent/README.md
+++ b/docs/services/edge-agent/README.md
@@ -12,7 +12,7 @@ The SignalBeam Edge Agent is a lightweight .NET console application that runs on
 
 ## Prerequisites
 
-- .NET 9.0 or later
+- .NET 10.0 or later
 - Docker (for container management)
 - Linux, macOS, or Windows
 

--- a/docs/services/edge-agent/package.md
+++ b/docs/services/edge-agent/package.md
@@ -18,7 +18,7 @@ This directory contains the packaging configuration and build scripts for distri
 
 ### Prerequisites
 
-- .NET 9.0 SDK
+- .NET 10.0 SDK
 - dpkg tools (`dpkg-deb`)
 - Linux system (or WSL on Windows)
 
@@ -221,7 +221,7 @@ Current sizes (approximate):
 - arm64: ~75-85 MB
 - armhf: ~70-80 MB
 
-To reduce size, you can use framework-dependent deployment (requires .NET 9.0 runtime on target):
+To reduce size, you can use framework-dependent deployment (requires .NET 10.0 runtime on target):
 ```bash
 dotnet publish -c Release -r linux-x64 --self-contained false
 ```

--- a/docs/services/edge-agent/systemd.md
+++ b/docs/services/edge-agent/systemd.md
@@ -23,7 +23,7 @@ This directory contains systemd service configuration and installation scripts f
 
 - Linux system with systemd (tested on Ubuntu 20.04+, Raspberry Pi OS)
 - Docker installed and running
-- .NET 9.0 runtime (or self-contained build)
+- .NET 10.0 runtime (or self-contained build)
 - Root/sudo access for installation
 
 ## Quick Start

--- a/docs/zitadel-aspire-setup.md
+++ b/docs/zitadel-aspire-setup.md
@@ -34,7 +34,7 @@ API Gateway (localhost:8080)
 
 ## Prerequisites
 
-1. **.NET 9 SDK** installed
+1. **.NET 10 SDK** installed
 2. **.NET Aspire Workload** installed:
    ```bash
    dotnet workload install aspire

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.102",
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/BundleOrchestrator/Dockerfile
+++ b/src/BundleOrchestrator/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy central package management files
@@ -28,7 +28,7 @@ WORKDIR /src/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host
 RUN dotnet publish -c Release -o /app/publish --no-restore
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine
 
 # Create non-root user
 RUN addgroup -S signalbeam && adduser -S signalbeam -G signalbeam

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Application/SignalBeam.BundleOrchestrator.Application.csproj
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Application/SignalBeam.BundleOrchestrator.Application.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.BundleOrchestrator.Application</RootNamespace>

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleAssignmentEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleAssignmentEndpoints.cs
@@ -14,8 +14,7 @@ public static class BundleAssignmentEndpoints
     public static IEndpointRouteBuilder MapBundleAssignmentEndpoints(this IEndpointRouteBuilder app)
     {
         var deviceGroup = app.MapGroup("/api/devices")
-            .WithTags("Bundle Assignments")
-            .WithOpenApi();
+            .WithTags("Bundle Assignments");
 
         deviceGroup.MapPost("/{deviceId}/bundle", AssignBundleToDevice)
             .WithName("AssignBundleToDevice")
@@ -28,8 +27,7 @@ public static class BundleAssignmentEndpoints
             .WithDescription("Retrieves the desired bundle state for a specific device.");
 
         var groupGroup = app.MapGroup("/api/device-groups")
-            .WithTags("Bundle Assignments")
-            .WithOpenApi();
+            .WithTags("Bundle Assignments");
 
         groupGroup.MapPost("/{deviceGroupId}/bundle", AssignBundleToGroup)
             .WithName("AssignBundleToGroup")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleEndpoints.cs
@@ -60,8 +60,7 @@ public static class BundleEndpoints
     public static IEndpointRouteBuilder MapBundleEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/bundles")
-            .WithTags("Bundles")
-            .WithOpenApi();
+            .WithTags("Bundles");
 
         group.MapPost("/", CreateBundle)
             .WithName("CreateBundle")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleVersionEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleVersionEndpoints.cs
@@ -18,8 +18,7 @@ public static class BundleVersionEndpoints
     public static IEndpointRouteBuilder MapBundleVersionEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/bundles/{bundleId}/versions")
-            .WithTags("Bundle Versions")
-            .WithOpenApi();
+            .WithTags("Bundle Versions");
 
         group.MapPost("/", CreateBundleVersion)
             .WithName("CreateBundleVersion")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/PhasedRolloutEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/PhasedRolloutEndpoints.cs
@@ -15,8 +15,7 @@ public static class PhasedRolloutEndpoints
     public static IEndpointRouteBuilder MapPhasedRolloutEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/phased-rollouts")
-            .WithTags("Phased Rollouts")
-            .WithOpenApi();
+            .WithTags("Phased Rollouts");
 
         // Query endpoints
         group.MapGet("", ListPhasedRollouts)

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/RolloutEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/RolloutEndpoints.cs
@@ -14,8 +14,7 @@ public static class RolloutEndpoints
     public static IEndpointRouteBuilder MapRolloutEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/rollouts")
-            .WithTags("Rollouts")
-            .WithOpenApi();
+            .WithTags("Rollouts");
 
         group.MapGet("", GetRollouts)
             .WithName("GetRollouts")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/RolloutStatusEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/RolloutStatusEndpoints.cs
@@ -14,8 +14,7 @@ public static class RolloutStatusEndpoints
     public static IEndpointRouteBuilder MapRolloutStatusEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/rollouts")
-            .WithTags("Rollout Status")
-            .WithOpenApi();
+            .WithTags("Rollout Status");
 
         group.MapGet("/bundles/{bundleId}", GetRolloutStatus)
             .WithName("GetRolloutStatus")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Program.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Program.cs
@@ -11,7 +11,7 @@ using SignalBeam.ServiceDefaults;
 using Scalar.AspNetCore;
 using SignalBeam.Shared.Infrastructure.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
 
@@ -27,7 +27,7 @@ builder.Host.UseSerilog((context, configuration) =>
 builder.AddServiceDefaults();
 
 // Add Azure Blob Storage (Azurite locally, Azure Blob Storage in production)
-builder.AddAzureBlobClient("blobs");
+builder.AddAzureBlobServiceClient("blobs");
 
 // Add Infrastructure (DbContext, Repositories)
 builder.Services.AddInfrastructure(builder.Configuration);

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/SignalBeam.BundleOrchestrator.Host.csproj
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/SignalBeam.BundleOrchestrator.Host.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>SignalBeam.BundleOrchestrator.Host</RootNamespace>

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Infrastructure/SignalBeam.BundleOrchestrator.Infrastructure.csproj
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Infrastructure/SignalBeam.BundleOrchestrator.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.BundleOrchestrator.Infrastructure</RootNamespace>

--- a/src/DeviceManager/Dockerfile
+++ b/src/DeviceManager/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy central package management files
@@ -28,7 +28,7 @@ WORKDIR /src/src/DeviceManager/SignalBeam.DeviceManager.Host
 RUN dotnet publish -c Release -o /app/publish --no-restore
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine
 
 # Create non-root user
 RUN addgroup -S signalbeam && adduser -S signalbeam -G signalbeam

--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/SignalBeam.DeviceManager.Application.csproj
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/SignalBeam.DeviceManager.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.DeviceManager.Application</RootNamespace>

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/CertificateEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/CertificateEndpoints.cs
@@ -21,8 +21,7 @@ public static class CertificateEndpoints
     public static IEndpointRouteBuilder MapCertificateEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/certificates")
-            .WithTags("Certificates")
-            .WithOpenApi();
+            .WithTags("Certificates");
 
         group.MapPost("/{deviceId:guid}/issue", IssueCertificate)
             .WithName("IssueCertificate")

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
@@ -24,8 +24,7 @@ public static class DeviceEndpoints
     public static IEndpointRouteBuilder MapDeviceEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/devices")
-            .WithTags("Devices")
-            .WithOpenApi();
+            .WithTags("Devices");
 
         group.MapPost("/", RegisterDevice)
             .WithName("RegisterDevice")
@@ -139,8 +138,7 @@ public static class DeviceEndpoints
 
         // Registration token management
         var tokenGroup = app.MapGroup("/api/registration-tokens")
-            .WithTags("Registration Tokens")
-            .WithOpenApi();
+            .WithTags("Registration Tokens");
 
         tokenGroup.MapPost("/", GenerateRegistrationToken)
             .WithName("GenerateRegistrationToken")

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/GroupEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/GroupEndpoints.cs
@@ -15,8 +15,7 @@ public static class GroupEndpoints
     public static IEndpointRouteBuilder MapGroupEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/groups")
-            .WithTags("Device Groups")
-            .WithOpenApi();
+            .WithTags("Device Groups");
 
         group.MapGet("/", GetDeviceGroups)
             .WithName("GetDeviceGroups")

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/TagEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/TagEndpoints.cs
@@ -15,8 +15,7 @@ public static class TagEndpoints
     public static IEndpointRouteBuilder MapTagEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/tags")
-            .WithTags("Tags")
-            .WithOpenApi();
+            .WithTags("Tags");
 
         group.MapGet("/", GetAllTags)
             .WithName("GetAllTags")
@@ -29,8 +28,7 @@ public static class TagEndpoints
             .WithDescription("Removes a specific tag from a device.");
 
         var searchGroup = app.MapGroup("/api/devices")
-            .WithTags("Devices")
-            .WithOpenApi();
+            .WithTags("Devices");
 
         searchGroup.MapGet("/search", SearchDevicesByTagQuery)
             .WithName("SearchDevicesByTagQuery")

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
@@ -11,7 +11,7 @@ using SignalBeam.ServiceDefaults;
 using Scalar.AspNetCore;
 using SignalBeam.Shared.Infrastructure.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
 

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/SignalBeam.DeviceManager.Host.csproj
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/SignalBeam.DeviceManager.Host.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>SignalBeam.DeviceManager.Host</RootNamespace>

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Caching/ValkeyCacheService.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/Caching/ValkeyCacheService.cs
@@ -72,7 +72,7 @@ public class ValkeyCacheService : ICacheService
             var db = _redis.GetDatabase();
             var serialized = JsonSerializer.Serialize(value, _jsonOptions);
 
-            await db.StringSetAsync(key, serialized, expiration);
+            await db.StringSetAsync(key, serialized, expiration, keepTtl: false);
 
             _logger.LogDebug(
                 "Set cache value for key: {Key} with expiration: {Expiration}",

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/SignalBeam.DeviceManager.Infrastructure.csproj
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/SignalBeam.DeviceManager.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.DeviceManager.Infrastructure</RootNamespace>

--- a/src/EdgeAgent/Dockerfile
+++ b/src/EdgeAgent/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy Directory.Build.props and Directory.Packages.props for central package management
@@ -26,7 +26,7 @@ WORKDIR /src/src/EdgeAgent/SignalBeam.EdgeAgent.Host
 RUN dotnet publish -c Release -o /app/publish --no-restore
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine
 
 # Install Docker CLI
 RUN apk add --no-cache docker-cli

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Application/SignalBeam.EdgeAgent.Application.csproj
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Application/SignalBeam.EdgeAgent.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.EdgeAgent.Application</RootNamespace>

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Host/SignalBeam.EdgeAgent.Host.csproj
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Host/SignalBeam.EdgeAgent.Host.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.EdgeAgent.Host</RootNamespace>

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Container/DockerContainerManager.cs
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/Container/DockerContainerManager.cs
@@ -237,7 +237,6 @@ public class DockerContainerManager : IContainerManager, IDisposable
             var logs = await _retryPolicy.ExecuteAsync(async () =>
                 await _client.Containers.GetContainerLogsAsync(
                     containerId,
-                    false, // tty - set to false for proper demultiplexing
                     new ContainerLogsParameters
                     {
                         ShowStdout = true,

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/SignalBeam.EdgeAgent.Infrastructure.csproj
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Infrastructure/SignalBeam.EdgeAgent.Infrastructure.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.EdgeAgent.Infrastructure</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" />
+    <PackageReference Include="Docker.DotNet.Enhanced" />
     <PackageReference Include="NATS.Client.Core" />
     <PackageReference Include="NATS.Client.JetStream" />
     <PackageReference Include="Polly" />

--- a/src/EdgeAgent/SignalBeam.EdgeAgent.Simulator/SignalBeam.EdgeAgent.Simulator.csproj
+++ b/src/EdgeAgent/SignalBeam.EdgeAgent.Simulator/SignalBeam.EdgeAgent.Simulator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>SignalBeam.EdgeAgent.Simulator</RootNamespace>

--- a/src/IdentityManager/Dockerfile
+++ b/src/IdentityManager/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy central package management files
@@ -28,7 +28,7 @@ WORKDIR /src/src/IdentityManager/SignalBeam.IdentityManager.Host
 RUN dotnet publish -c Release -o /app/publish --no-restore
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine
 
 # Create non-root user
 RUN addgroup -S signalbeam && adduser -S signalbeam -G signalbeam

--- a/src/IdentityManager/SignalBeam.IdentityManager.Application/SignalBeam.IdentityManager.Application.csproj
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Application/SignalBeam.IdentityManager.Application.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.IdentityManager.Application</RootNamespace>

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/AuthEndpoints.cs
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/AuthEndpoints.cs
@@ -14,8 +14,7 @@ public static class AuthEndpoints
     public static IEndpointRouteBuilder MapAuthEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/auth")
-            .WithTags("Authentication")
-            .WithOpenApi();
+            .WithTags("Authentication");
 
         group.MapPost("/register", RegisterUser)
             .WithName("RegisterUser")

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/SubscriptionEndpoints.cs
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/SubscriptionEndpoints.cs
@@ -18,8 +18,7 @@ public static class SubscriptionEndpoints
     {
         var group = app.MapGroup("/api/subscriptions")
             .WithTags("Subscriptions")
-            .RequireAuthorization()
-            .WithOpenApi();
+            .RequireAuthorization();
 
         group.MapGet("/", GetSubscription)
             .WithName("GetSubscription")

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/TeamEndpoints.cs
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/TeamEndpoints.cs
@@ -18,7 +18,6 @@ public static class TeamEndpoints
     {
         var group = app.MapGroup("/api/teams")
             .WithTags("Teams")
-            .WithOpenApi()
             .RequireAuthorization();
 
         // Admin-only endpoints

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/TenantEndpoints.cs
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/TenantEndpoints.cs
@@ -11,8 +11,7 @@ public static class TenantEndpoints
     public static IEndpointRouteBuilder MapTenantEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/tenants")
-            .WithTags("Tenants")
-            .WithOpenApi();
+            .WithTags("Tenants");
 
         group.MapGet("/retention-policies", GetTenantRetentionPolicies)
             .WithName("GetTenantRetentionPolicies")

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/UserEndpoints.cs
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/Endpoints/UserEndpoints.cs
@@ -13,7 +13,6 @@ public static class UserEndpoints
     {
         var group = app.MapGroup("/api/users")
             .WithTags("Users")
-            .WithOpenApi()
             .RequireAuthorization();
 
         group.MapPut("/me/profile", UpdateProfile)

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/Program.cs
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/Program.cs
@@ -6,7 +6,7 @@ using Serilog;
 using SignalBeam.ServiceDefaults;
 using Scalar.AspNetCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Microsoft.EntityFrameworkCore;
 using SignalBeam.IdentityManager.Infrastructure.Persistence;
 using System.Text.Json;

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/SignalBeam.IdentityManager.Host.csproj
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/SignalBeam.IdentityManager.Host.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>SignalBeam.IdentityManager.Host</RootNamespace>

--- a/src/IdentityManager/SignalBeam.IdentityManager.Infrastructure/SignalBeam.IdentityManager.Infrastructure.csproj
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Infrastructure/SignalBeam.IdentityManager.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.IdentityManager.Infrastructure</RootNamespace>

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/AzureAdConfiguration.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/AzureAdConfiguration.cs
@@ -42,7 +42,6 @@ public static class AzureAdConfiguration
         {
             ExcludeEnvironmentCredential = false,
             ExcludeManagedIdentityCredential = false,
-            ExcludeSharedTokenCacheCredential = true,
             ExcludeVisualStudioCredential = true,
             ExcludeVisualStudioCodeCredential = true,
             ExcludeAzureCliCredential = false,

--- a/src/Shared/SignalBeam.Shared.Infrastructure/SignalBeam.Shared.Infrastructure.csproj
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/SignalBeam.Shared.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Polly" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/src/SignalBeam.ApiGateway/Dockerfile
+++ b/src/SignalBeam.ApiGateway/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy central package management files
@@ -23,7 +23,7 @@ WORKDIR /src/src/SignalBeam.ApiGateway
 RUN dotnet publish -c Release -o /app/publish --no-restore
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine
 
 # Create non-root user
 RUN addgroup -S signalbeam && adduser -S signalbeam -G signalbeam

--- a/src/SignalBeam.AppHost/SignalBeam.AppHost.csproj
+++ b/src/SignalBeam.AppHost/SignalBeam.AppHost.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.1.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.1" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>signalbeam-apphost-secrets</UserSecretsId>
   </PropertyGroup>

--- a/src/SignalBeam.ServiceDefaults/SignalBeam.ServiceDefaults.csproj
+++ b/src/SignalBeam.ServiceDefaults/SignalBeam.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsAspireSharedProject>true</IsAspireSharedProject>
   </PropertyGroup>
 

--- a/src/SignalBeam.ZitadelSetup/SignalBeam.ZitadelSetup.csproj
+++ b/src/SignalBeam.ZitadelSetup/SignalBeam.ZitadelSetup.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>false</IsAspireSharedProject>

--- a/src/TelemetryProcessor/Dockerfile
+++ b/src/TelemetryProcessor/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy central package management files
@@ -28,7 +28,7 @@ WORKDIR /src/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Host
 RUN dotnet publish -c Release -o /app/publish --no-restore
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine
 
 # Create non-root user
 RUN addgroup -S signalbeam && adduser -S signalbeam -G signalbeam

--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Application/SignalBeam.TelemetryProcessor.Application.csproj
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Application/SignalBeam.TelemetryProcessor.Application.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.TelemetryProcessor.Application</RootNamespace>

--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Host/SignalBeam.TelemetryProcessor.Host.csproj
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Host/SignalBeam.TelemetryProcessor.Host.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>SignalBeam.TelemetryProcessor.Host</RootNamespace>

--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/SignalBeam.TelemetryProcessor.Infrastructure.csproj
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/SignalBeam.TelemetryProcessor.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SignalBeam.TelemetryProcessor.Infrastructure</RootNamespace>

--- a/src/tests/SignalBeam.BundleOrchestrator.Application.Tests/SignalBeam.BundleOrchestrator.Application.Tests.csproj
+++ b/src/tests/SignalBeam.BundleOrchestrator.Application.Tests/SignalBeam.BundleOrchestrator.Application.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/tests/SignalBeam.BundleOrchestrator.Integration.Tests/Fixtures/DatabaseFixture.cs
+++ b/src/tests/SignalBeam.BundleOrchestrator.Integration.Tests/Fixtures/DatabaseFixture.cs
@@ -18,8 +18,7 @@ public class DatabaseFixture : IAsyncLifetime
 
     public DatabaseFixture()
     {
-        _postgresContainer = new PostgreSqlBuilder()
-            .WithImage("postgres:16-alpine")
+        _postgresContainer = new PostgreSqlBuilder("postgres:16-alpine")
             .WithDatabase("signalbeam_test")
             .WithUsername("postgres")
             .WithPassword("postgres")

--- a/src/tests/SignalBeam.BundleOrchestrator.Integration.Tests/SignalBeam.BundleOrchestrator.Integration.Tests.csproj
+++ b/src/tests/SignalBeam.BundleOrchestrator.Integration.Tests/SignalBeam.BundleOrchestrator.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/tests/SignalBeam.Domain.Tests/SignalBeam.Domain.Tests.csproj
+++ b/src/tests/SignalBeam.Domain.Tests/SignalBeam.Domain.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/tests/SignalBeam.Shared.Infrastructure.Tests/SignalBeam.Shared.Infrastructure.Tests.csproj
+++ b/src/tests/SignalBeam.Shared.Infrastructure.Tests/SignalBeam.Shared.Infrastructure.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/SignalBeam.BundleOrchestrator.Tests.Unit/SignalBeam.BundleOrchestrator.Tests.Unit.csproj
+++ b/tests/SignalBeam.BundleOrchestrator.Tests.Unit/SignalBeam.BundleOrchestrator.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/AuthenticationAndRateLimitingTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/AuthenticationAndRateLimitingTests.cs
@@ -158,7 +158,7 @@ public class AuthenticationAndRateLimitingTests : IClassFixture<DeviceManagerWeb
 
         // Assert - Should have some rate-limited requests
         rateLimitedRequests.Should().BeGreaterThan(0, "Rate limiting should kick in after 100 requests");
-        successfulRequests.Should().BeLessOrEqualTo(100, "Should not exceed the rate limit");
+        successfulRequests.Should().BeLessThanOrEqualTo(100, "Should not exceed the rate limit");
     }
 
     [Fact]

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/DeviceEndpointsTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/DeviceEndpointsTests.cs
@@ -149,7 +149,7 @@ public class DeviceEndpointsTests : IClassFixture<DeviceManagerWebApplicationFac
 
         var result = await response.Content.ReadFromJsonAsync<GetDevicesResponse>();
         result.Should().NotBeNull();
-        result!.Devices.Should().HaveCountGreaterOrEqualTo(3);
+        result!.Devices.Should().HaveCountGreaterThanOrEqualTo(3);
     }
 
     [Fact]
@@ -174,7 +174,7 @@ public class DeviceEndpointsTests : IClassFixture<DeviceManagerWebApplicationFac
 
         var result = await response.Content.ReadFromJsonAsync<GetDevicesResponse>();
         result.Should().NotBeNull();
-        result!.Devices.Should().HaveCountLessOrEqualTo(2);
+        result!.Devices.Should().HaveCountLessThanOrEqualTo(2);
     }
 
     [Fact]

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/GroupEndpointsTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/GroupEndpointsTests.cs
@@ -80,7 +80,7 @@ public class GroupEndpointsTests : IClassFixture<DeviceManagerWebApplicationFact
 
         var result = await response.Content.ReadFromJsonAsync<GetDeviceGroupsResponse>();
         result.Should().NotBeNull();
-        result!.Groups.Should().HaveCountGreaterOrEqualTo(3);
+        result!.Groups.Should().HaveCountGreaterThanOrEqualTo(3);
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class GroupEndpointsTests : IClassFixture<DeviceManagerWebApplicationFact
 
         var result = await response.Content.ReadFromJsonAsync<GetDevicesByGroupResponse>();
         result.Should().NotBeNull();
-        result!.Devices.Should().HaveCountGreaterOrEqualTo(3);
+        result!.Devices.Should().HaveCountGreaterThanOrEqualTo(3);
     }
 
     [Fact]
@@ -221,7 +221,7 @@ public class GroupEndpointsTests : IClassFixture<DeviceManagerWebApplicationFact
 
         var result = await response.Content.ReadFromJsonAsync<GetDevicesByGroupResponse>();
         result.Should().NotBeNull();
-        result!.Devices.Should().HaveCountLessOrEqualTo(2);
+        result!.Devices.Should().HaveCountLessThanOrEqualTo(2);
     }
 
     [Fact]

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/Infrastructure/DeviceManagerTestFixture.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/Infrastructure/DeviceManagerTestFixture.cs
@@ -12,8 +12,7 @@ public class DeviceManagerTestFixture : IAsyncLifetime
 
     public DeviceManagerTestFixture()
     {
-        _postgresContainer = new PostgreSqlBuilder()
-            .WithImage("timescale/timescaledb:latest-pg16")
+        _postgresContainer = new PostgreSqlBuilder("timescale/timescaledb:latest-pg16")
             .WithDatabase("signalbeam_test")
             .WithUsername("postgres")
             .WithPassword("postgres")

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/Infrastructure/DeviceManagerWebApplicationFactory.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/Infrastructure/DeviceManagerWebApplicationFactory.cs
@@ -23,8 +23,7 @@ public class DeviceManagerWebApplicationFactory : WebApplicationFactory<Program>
 
     public DeviceManagerWebApplicationFactory()
     {
-        _postgresContainer = new PostgreSqlBuilder()
-            .WithImage("timescale/timescaledb:latest-pg16")
+        _postgresContainer = new PostgreSqlBuilder("timescale/timescaledb:latest-pg16")
             .WithDatabase("signalbeam_test")
             .WithUsername("postgres")
             .WithPassword("postgres")

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/SignalBeam.DeviceManager.Tests.Integration.csproj
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/SignalBeam.DeviceManager.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/SignalBeam.DeviceManager.Tests.Unit/SignalBeam.DeviceManager.Tests.Unit.csproj
+++ b/tests/SignalBeam.DeviceManager.Tests.Unit/SignalBeam.DeviceManager.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/SignalBeam.EdgeAgent.Tests.Integration/SignalBeam.EdgeAgent.Tests.Integration.csproj
+++ b/tests/SignalBeam.EdgeAgent.Tests.Integration/SignalBeam.EdgeAgent.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/SignalBeam.EdgeAgent.Tests.Unit/SignalBeam.EdgeAgent.Tests.Unit.csproj
+++ b/tests/SignalBeam.EdgeAgent.Tests.Unit/SignalBeam.EdgeAgent.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/SignalBeam.Shared.Infrastructure.Tests/SignalBeam.Shared.Infrastructure.Tests.csproj
+++ b/tests/SignalBeam.Shared.Infrastructure.Tests/SignalBeam.Shared.Infrastructure.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests/Persistence/DeviceHeartbeatRepositoryTests.cs
+++ b/tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests/Persistence/DeviceHeartbeatRepositoryTests.cs
@@ -20,8 +20,7 @@ public class DeviceHeartbeatRepositoryTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _postgresContainer = new PostgreSqlBuilder()
-            .WithImage("timescale/timescaledb:latest-pg16")
+        _postgresContainer = new PostgreSqlBuilder("timescale/timescaledb:latest-pg16")
             .WithDatabase("telemetry_test")
             .WithUsername("postgres")
             .WithPassword("postgres")

--- a/tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests/Persistence/DeviceMetricsRepositoryTests.cs
+++ b/tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests/Persistence/DeviceMetricsRepositoryTests.cs
@@ -22,8 +22,7 @@ public class DeviceMetricsRepositoryTests : IAsyncLifetime
     public async Task InitializeAsync()
     {
         // Create and start PostgreSQL container with TimescaleDB extension
-        _postgresContainer = new PostgreSqlBuilder()
-            .WithImage("timescale/timescaledb:latest-pg16")
+        _postgresContainer = new PostgreSqlBuilder("timescale/timescaledb:latest-pg16")
             .WithDatabase("telemetry_test")
             .WithUsername("postgres")
             .WithPassword("postgres")

--- a/tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests.csproj
+++ b/tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/SignalBeam.TelemetryProcessor.Tests.Integration/Infrastructure/TelemetryProcessorTestFixture.cs
+++ b/tests/SignalBeam.TelemetryProcessor.Tests.Integration/Infrastructure/TelemetryProcessorTestFixture.cs
@@ -20,8 +20,7 @@ public class TelemetryProcessorTestFixture : IAsyncLifetime
 
     public TelemetryProcessorTestFixture()
     {
-        _postgresContainer = new PostgreSqlBuilder()
-            .WithImage("timescale/timescaledb:latest-pg16")
+        _postgresContainer = new PostgreSqlBuilder("timescale/timescaledb:latest-pg16")
             .WithDatabase("signalbeam_test")
             .WithUsername("postgres")
             .WithPassword("postgres")

--- a/tests/SignalBeam.TelemetryProcessor.Tests.Integration/Infrastructure/TelemetryProcessorWebApplicationFactory.cs
+++ b/tests/SignalBeam.TelemetryProcessor.Tests.Integration/Infrastructure/TelemetryProcessorWebApplicationFactory.cs
@@ -24,8 +24,7 @@ public class TelemetryProcessorWebApplicationFactory : WebApplicationFactory<Pro
 
     public TelemetryProcessorWebApplicationFactory()
     {
-        _postgresContainer = new PostgreSqlBuilder()
-            .WithImage("timescale/timescaledb:latest-pg16")
+        _postgresContainer = new PostgreSqlBuilder("timescale/timescaledb:latest-pg16")
             .WithDatabase("signalbeam_test")
             .WithUsername("postgres")
             .WithPassword("postgres")

--- a/tests/SignalBeam.TelemetryProcessor.Tests.Integration/SignalBeam.TelemetryProcessor.Tests.Integration.csproj
+++ b/tests/SignalBeam.TelemetryProcessor.Tests.Integration/SignalBeam.TelemetryProcessor.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary

Aligns the toolchain with the [`makigjuro/reachloop`](https://github.com/makigjuro/reachloop) repo and adds an OIDC-based Azure Container Apps deploy workflow.

**Toolchain bumps**
- **.NET 9 → 10** — `global.json` SDK `10.0.102`, all projects `net10.0`, AppHost `Aspire.AppHost.Sdk 13.2.1`
- **Aspire** 9.1 → 13.2.1, **EF Core** 9 → 10.0.9, **WolverineFx** 3.7 → 5.27, **OpenTelemetry** 1.10 → 1.15.3, **FluentAssertions** 6 → 8.9, **Testcontainers** 4.0 → 4.11
- Dropped the OpenTelemetry CVE audit suppression (Wolverine 5 + OTel 1.15 make it unnecessary) and enabled `CentralPackageTransitivePinningEnabled` to pin patched transitive packages (DataProtection/Crypto.Xml `10.0.9`, MessagePack `2.5.302`, OpenTelemetry.Api `1.15.3`) without polluting the Domain layer.

**Breaking-change fixes**
- Removed deprecated minimal-API `.WithOpenApi()` (metadata is automatic in .NET 10)
- `AddAzureBlobClient` → `AddAzureBlobServiceClient`; `Microsoft.OpenApi.Models` → `Microsoft.OpenApi` (OpenAPI 2.0)
- Redis `StringSetAsync` `keepTtl:` arg; removed obsolete `ExcludeSharedTokenCacheCredential`
- Testcontainers `PostgreSqlBuilder("image")` ctor; FluentAssertions 8 method renames (`*OrEqualTo` → `*ThanOrEqualTo`)
- **EdgeAgent → `Docker.DotNet.Enhanced`** — the fork Testcontainers 4.11 uses; avoids a conflicting `Docker.DotNet` assembly in test output (`GetContainerLogsAsync` lost its `tty` param)

**Infra & CI**
- Bumped all 7 Dockerfiles (`sdk`/`aspnet` 9.0 → 10.0) and CI `dotnet-version` 9.0.x → 10.0.x
- New `.github/workflows/deploy.yml`: OIDC → build/push to GHCR → `az containerapp update` → wait-for-revision → `/health/live` smoke test, over a matrix of the five backend services. Existing Terragrunt/Terraform infra left untouched.

**Docs** — `.NET 9 → 10` / `C# 13 → 14` across CLAUDE.md, README, and docs; documented the new deploy workflow in `docs/operations/deployment.md`.

## Test plan
- ✅ `dotnet build src/SignalBeam.sln` — 0 warnings, 0 errors (warnings-as-errors)
- ✅ Unit tests: **340 pass** (Domain + NetArchTest 117, EdgeAgent 54, IdentityManager 53, BundleOrchestrator 48, DeviceManager 29, Shared 39)
- ✅ TelemetryProcessor.Infrastructure (Testcontainers): 19 pass / 1 skip
- ✅ EdgeAgent.Tests.Integration: 7 pass / 1 fail — matches the pre-upgrade `main` baseline
- ⚠️ DeviceManager & TelemetryProcessor integration suites have failures that are **pre-existing on `main`** (verified by stashing) — e.g. tests POST `/api/devices/register` while the route is `POST /api/devices/`. Out of scope for this upgrade.

## Deploy prerequisites (one-time, for `deploy.yml`)
- Azure AD app + federated credential for this repo/branch → `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets
- Deployer service principal needs **Contributor** on each `sb-ca-*-dev` app
- Apps already hold the `ghcr-pat` registry secret to pull private GHCR images

🤖 Generated with [Claude Code](https://claude.com/claude-code)