### PR TITLE
fix service image builds (dockerignore + image names)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,13 +32,9 @@
 # systemd files (not needed in container)
 **/systemd/
 
-# Exclude other services (we only need Shared and EdgeAgent)
-src/DeviceManager/
-src/BundleOrchestrator/
-src/TelemetryProcessor/
-src/SignalBeam.AppHost/
-src/SignalBeam.ApiGateway/
-src/SignalBeam.ServiceDefaults/
+# NOTE: do not exclude src/<service>/ or src/SignalBeam.ServiceDefaults/ here.
+# All service image builds use the repo root as build context and share this
+# file, so excluding any service dir breaks that service's own COPY steps.
 
 # Tests
 tests/

--- a/.github/workflows/build-api-gateway.yml
+++ b/.github/workflows/build-api-gateway.yml
@@ -23,6 +23,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-service.yml
     with:
-      service-name: api-gateway
+      service-name: apigateway
       dockerfile: ./src/SignalBeam.ApiGateway/Dockerfile
       context: .

--- a/.github/workflows/build-bundle-orchestrator.yml
+++ b/.github/workflows/build-bundle-orchestrator.yml
@@ -25,6 +25,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-service.yml
     with:
-      service-name: bundle-orchestrator
+      service-name: bundleorchestrator
       dockerfile: ./src/BundleOrchestrator/Dockerfile
       context: .

--- a/.github/workflows/build-device-manager.yml
+++ b/.github/workflows/build-device-manager.yml
@@ -25,6 +25,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-service.yml
     with:
-      service-name: device-manager
+      service-name: devicemanager
       dockerfile: ./src/DeviceManager/Dockerfile
       context: .

--- a/.github/workflows/build-identity-manager.yml
+++ b/.github/workflows/build-identity-manager.yml
@@ -25,6 +25,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-service.yml
     with:
-      service-name: identity-manager
+      service-name: identitymanager
       dockerfile: ./src/IdentityManager/Dockerfile
       context: .

--- a/.github/workflows/build-telemetry-processor.yml
+++ b/.github/workflows/build-telemetry-processor.yml
@@ -25,6 +25,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-service.yml
     with:
-      service-name: telemetry-processor
+      service-name: telemetryprocessor
       dockerfile: ./src/TelemetryProcessor/Dockerfile
       context: .


### PR DESCRIPTION
## Summary
Makes the `build-*` workflows actually produce deployable images. After #379 fixed the `startup_failure`, two bugs remained:

1. **`.dockerignore` excluded the service source** — the root `.dockerignore` listed `src/DeviceManager/`, `src/SignalBeam.ServiceDefaults/`, etc. Since every service image build uses the repo root as context and shares this file, the Dockerfile `COPY src/<service>/…` steps failed with `not found`. Removed the exclusion block.
2. **Image name mismatch** — CI pushed hyphenated names (`device-manager`) while the deployed ACA apps pull non-hyphenated names (`devicemanager`). Aligned the 5 `service-name` inputs.

## Verification
Built `DeviceManager` locally with the fixed `.dockerignore` — context resolves, all .NET 10 projects compile, image produced.

## After merge
Dispatch the 5 build workflows on `main` (they push `ghcr.io/signalbeam-io/{apigateway,devicemanager,bundleorchestrator,telemetryprocessor,identitymanager}:latest`), then restart the ACA apps to pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)