### PR TITLE
fix telemetry + identity container startup on ACA

### DIFF
--- a/infra/terraform/modules/container-app/main.tf
+++ b/infra/terraform/modules/container-app/main.tf
@@ -112,6 +112,27 @@ resource "azurerm_container_app" "this" {
           interval_seconds = 15
         }
       }
+
+      # TCP startup + readiness probes for TCP-ingress apps (NATS). ACA only
+      # opens the internal TCP ingress listener once it confirms the port
+      # accepts connections; an HTTP liveness probe on a different port (8222)
+      # is not enough to mark the TCP client port (4222) ready for routing.
+      dynamic "startup_probe" {
+        for_each = var.tcp_probe_port > 0 ? [1] : []
+        content {
+          transport = "TCP"
+          port      = var.tcp_probe_port
+        }
+      }
+
+      dynamic "readiness_probe" {
+        for_each = var.tcp_probe_port > 0 ? [1] : []
+        content {
+          transport        = "TCP"
+          port             = var.tcp_probe_port
+          interval_seconds = 10
+        }
+      }
     }
   }
 

--- a/infra/terraform/modules/container-app/variables.tf
+++ b/infra/terraform/modules/container-app/variables.tf
@@ -115,6 +115,12 @@ variable "readiness_probe_path" {
   default     = ""
 }
 
+variable "tcp_probe_port" {
+  description = "Container TCP port for startup + readiness probes (0 = disabled). Set to the NATS client port so ACA confirms the TCP port accepts connections and opens the internal TCP ingress listener; without a TCP-port readiness signal the internal LB may never route the TCP port."
+  type        = number
+  default     = 0
+}
+
 # --- Environment & secrets ---
 
 variable "env_vars" {

--- a/infra/terragrunt/dev/aca/nats/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/nats/terragrunt.hcl
@@ -54,8 +54,11 @@ inputs = {
   managed_identity_id          = dependency.managed_identity.outputs.id
 
   # Public upstream image — no private registry credentials needed.
-  image   = "nats:2.10-alpine"
-  command = ["nats-server", "--jetstream", "--store_dir=/data", "--http_port=8222"]
+  image = "nats:2.10-alpine"
+  # --no_advertise stops NATS from gossiping its internal pod IP to clients in
+  # the INFO handshake; behind the ACA Envoy TCP proxy that advertised IP is
+  # unreachable, which can break NATS .NET client connections.
+  command = ["nats-server", "--jetstream", "--store_dir=/data", "--http_port=8222", "--no_advertise"]
 
   # The one always-on service: persistent JetStream, cannot scale to zero.
   min_replicas = 1
@@ -71,6 +74,11 @@ inputs = {
   # NATS monitoring endpoint (/healthz on 8222) to catch a hung JetStream.
   liveness_probe_path = "/healthz"
   liveness_probe_port = 8222
+
+  # TCP startup + readiness probes on the client port so ACA confirms 4222 is
+  # accepting and opens the internal TCP ingress listener (otherwise app-to-app
+  # connections to nats://...:4222 time out even though NATS is healthy).
+  tcp_probe_port = 4222
 
   # JetStream persistence on the Azure Files share registered with the environment.
   volumes = [

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/appsettings.json
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/appsettings.json
@@ -7,13 +7,6 @@
     }
   },
   "AllowedHosts": "*",
-  "Kestrel": {
-    "Endpoints": {
-      "Http": {
-        "Url": "http://localhost:5004"
-      }
-    }
-  },
   "ConnectionStrings": {
     "signalbeam": "Host=localhost;Database=signalbeam;Username=postgres;Password=postgres"
   },

--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Host/Program.cs
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Host/Program.cs
@@ -17,6 +17,14 @@ builder.Host.UseSerilog((context, configuration) =>
 // Add Aspire ServiceDefaults (OpenTelemetry, Service Discovery, Health Checks)
 builder.AddServiceDefaults();
 
+// A broker outage must not take down the whole service. The NATS background
+// services (consumer + SSE bridge) throw a fatal exception when NATS is
+// unreachable; with the default StopHost behavior that crashes the host and the
+// container crash-loops. Ignore lets the host stay up (serving HTTP + health)
+// while NATS-dependent features degrade until connectivity is restored.
+builder.Services.Configure<HostOptions>(options =>
+    options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
+
 // Add TelemetryProcessor Infrastructure (DbContext, NATS, Repositories, Message Handlers)
 builder.Services.AddTelemetryProcessorInfrastructure(builder.Configuration);
 


### PR DESCRIPTION
## Summary
Fixes the two services that stayed `ActivationFailed` after the North Europe deploy. These are **two distinct, non-NATS-routing bugs** (the ACA internal TCP-ingress-to-NATS limitation is tracked separately):

1. **IdentityManager — Kestrel binding.** `appsettings.json` hardcoded `Kestrel:Endpoints:Http:Url = http://localhost:5004`, which overrode the ACA-injected `ASPNETCORE_URLS=http://+:8080`. The container bound to loopback on the wrong port, so health probes on 8080 were connection-refused and it crash-looped. Removed the section (the 3 working services have none) so the runtime dictates the binding.

2. **TelemetryProcessor — host crash on NATS failure.** Its NATS background services throw a fatal exception when NATS is unreachable; the default `BackgroundServiceExceptionBehavior=StopHost` crashed the whole host. Set it to `Ignore` so the host stays up (HTTP + health serving) and NATS-dependent features degrade gracefully until NATS connectivity is solved.

3. **Infra (NATS probes).** Added a `tcp_probe_port` option to the container-app module (TCP startup+readiness probes) wired to 4222 for NATS, plus `--no_advertise`. Confirms NATS health on the client port; does **not** fix ACA internal TCP-ingress routing (separate issue).

## Verification
Both services build clean (`dotnet build`, 0 warnings/errors); identity `appsettings.json` validated as JSON.

## After merge
CI builds + pushes new `telemetryprocessor` and `identitymanager` images; then `az containerapp update` both to pull. Expected: both reach `Running`. TelemetryProcessor runs with NATS degraded (known follow-up: NATS-over-WebSocket or move NATS to AKS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)