### PR TITLE
deploy web dashboard to Azure Static Web Apps

### DIFF
--- a/.github/workflows/deploy-web-swa.yml
+++ b/.github/workflows/deploy-web-swa.yml
@@ -63,6 +63,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Close PR Preview
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
       - name: Close preview environment
         uses: Azure/static-web-apps-deploy@v1
         with:

--- a/.github/workflows/deploy-web-swa.yml
+++ b/.github/workflows/deploy-web-swa.yml
@@ -1,0 +1,70 @@
+name: Deploy Web (Static Web Apps)
+
+# Builds and deploys the React dashboard (web/) to Azure Static Web Apps (Free).
+# This is separate from build-web.yml, which still builds the GHCR Docker image
+# used by the Helm/k8s hosting path. SWA does not consume that image — it builds
+# the Vite app via Oryx and serves the static output.
+#
+# Prerequisites (see infra/terragrunt/dev/aca/README.md):
+#   - Provision the SWA: `terragrunt apply --working-dir infra/terragrunt/dev/static-web-app`
+#   - Secret  AZURE_STATIC_WEB_APPS_API_TOKEN  = the module's `api_key` output
+#   - Repo variables (Settings → Secrets and variables → Actions → Variables):
+#       VITE_API_URL             = https://<apigateway-host>   (the ACA gateway)
+#       VITE_AUTH_MODE           = zitadel
+#       VITE_ZITADEL_AUTHORITY   = https://<zitadel-instance>
+#       VITE_ZITADEL_CLIENT_ID   = <spa client id>
+#       VITE_ZITADEL_PROJECT_ID  = <project id>
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/deploy-web-swa.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'web/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write # SWA posts preview-environment URLs as PR comments
+
+jobs:
+  build-and-deploy:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    name: Build and Deploy
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Build and Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: 'web'
+          output_location: 'dist'
+        env:
+          # Baked into the bundle at build time by Vite. Configure as repo variables.
+          VITE_API_URL: ${{ vars.VITE_API_URL }}
+          VITE_AUTH_MODE: ${{ vars.VITE_AUTH_MODE }}
+          VITE_ZITADEL_AUTHORITY: ${{ vars.VITE_ZITADEL_AUTHORITY }}
+          VITE_ZITADEL_CLIENT_ID: ${{ vars.VITE_ZITADEL_CLIENT_ID }}
+          VITE_ZITADEL_PROJECT_ID: ${{ vars.VITE_ZITADEL_PROJECT_ID }}
+
+  close-pr-preview:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close PR Preview
+    steps:
+      - name: Close preview environment
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: close

--- a/infra/terraform/modules/static-web-app/main.tf
+++ b/infra/terraform/modules/static-web-app/main.tf
@@ -1,5 +1,6 @@
 locals {
-  name = "${var.project}-swa-web-${var.environment}"
+  location_short = lookup({ westeurope = "weu", northeurope = "neu" }, var.location, "weu")
+  name           = "${var.project}-swa-web-${var.environment}-${local.location_short}"
 }
 
 # Azure Static Web Apps hosts the React dashboard (web/) on a permanent

--- a/infra/terraform/modules/static-web-app/main.tf
+++ b/infra/terraform/modules/static-web-app/main.tf
@@ -1,0 +1,19 @@
+locals {
+  name = "${var.project}-swa-web-${var.environment}"
+}
+
+# Azure Static Web Apps hosts the React dashboard (web/) on a permanent
+# *.azurestaticapps.net URL. The Free tier is sufficient for the dev dashboard.
+#
+# Note: SWA is only offered in a handful of regions and is NOT available in
+# northeurope (the rest of the lean ACA stack lives there). The location is
+# pinned to West Europe via the terragrunt wrapper — see variables.tf default.
+resource "azurerm_static_web_app" "this" {
+  name                = local.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  sku_tier            = var.sku_tier
+  sku_size            = var.sku_size
+
+  tags = var.tags
+}

--- a/infra/terraform/modules/static-web-app/outputs.tf
+++ b/infra/terraform/modules/static-web-app/outputs.tf
@@ -1,0 +1,20 @@
+output "id" {
+  description = "Static Web App resource ID"
+  value       = azurerm_static_web_app.this.id
+}
+
+output "name" {
+  description = "Static Web App name"
+  value       = azurerm_static_web_app.this.name
+}
+
+output "default_host_name" {
+  description = "Default *.azurestaticapps.net hostname for the dashboard"
+  value       = azurerm_static_web_app.this.default_host_name
+}
+
+output "api_key" {
+  description = "Deployment API token used by the GitHub Actions deploy workflow. Store as the AZURE_STATIC_WEB_APPS_API_TOKEN repo secret."
+  value       = azurerm_static_web_app.this.api_key
+  sensitive   = true
+}

--- a/infra/terraform/modules/static-web-app/variables.tf
+++ b/infra/terraform/modules/static-web-app/variables.tf
@@ -21,15 +21,25 @@ variable "resource_group_name" {
 }
 
 variable "sku_tier" {
-  description = "Static Web App SKU tier"
+  description = "Static Web App SKU tier (must match sku_size)"
   type        = string
   default     = "Free"
+
+  validation {
+    condition     = contains(["Free", "Standard"], var.sku_tier)
+    error_message = "sku_tier must be \"Free\" or \"Standard\"."
+  }
 }
 
 variable "sku_size" {
-  description = "Static Web App SKU size"
+  description = "Static Web App SKU size (must match sku_tier)"
   type        = string
   default     = "Free"
+
+  validation {
+    condition     = contains(["Free", "Standard"], var.sku_size)
+    error_message = "sku_size must be \"Free\" or \"Standard\"."
+  }
 }
 
 variable "tags" {

--- a/infra/terraform/modules/static-web-app/variables.tf
+++ b/infra/terraform/modules/static-web-app/variables.tf
@@ -1,0 +1,39 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region for the Static Web App. SWA is not available in every region (e.g. not northeurope) — defaults to West Europe."
+  type        = string
+  default     = "westeurope"
+}
+
+variable "project" {
+  description = "Project prefix for resource naming"
+  type        = string
+  default     = "sb"
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group"
+  type        = string
+}
+
+variable "sku_tier" {
+  description = "Static Web App SKU tier"
+  type        = string
+  default     = "Free"
+}
+
+variable "sku_size" {
+  description = "Static Web App SKU size"
+  type        = string
+  default     = "Free"
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terragrunt/dev/aca/README.md
+++ b/infra/terragrunt/dev/aca/README.md
@@ -81,9 +81,18 @@ terragrunt run --all apply --queue-include-dir ./resource-group --queue-include-
   --queue-include-dir ./managed-identity --queue-include-dir ./monitoring \
   --queue-include-dir ./key-vault --queue-include-dir ./postgresql
 
+# Web dashboard host (SWA) — apply before the ACA stack: the apigateway unit
+# reads its hostname to allow-list the dashboard origin for CORS.
+terragrunt apply --working-dir ./static-web-app
+
 # ACA stack
 terragrunt run --all apply --working-dir ./aca
 ```
+
+> The `apigateway` unit depends on `static-web-app` for its CORS origin. Apply
+> `static-web-app` first (one-time) so `terragrunt run --all ./aca` can resolve
+> the hostname; otherwise the gateway apply fails on the missing dependency
+> output. See [Web dashboard](#web-dashboard-azure-static-web-apps) below.
 
 ### Set the GHCR PAT (out-of-band — never in Terraform state)
 
@@ -115,6 +124,55 @@ registration handshake is reachable:
 ```bash
 curl -i https://<apigateway-fqdn>/api/devices   # routed by YARP to DeviceManager
 ```
+
+## Web dashboard (Azure Static Web Apps)
+
+The React dashboard (`web/`) is hosted on **Azure Static Web Apps (Free)**, giving
+a permanent `https://<name>.azurestaticapps.net` URL (issue #383). SWA is a
+separate unit from the ACA stack — it lives in `infra/terragrunt/dev/static-web-app`
+and is **pinned to West Europe** because the Free tier is not offered in
+northeurope.
+
+```bash
+# Provision the Static Web App (one-time)
+terragrunt apply --working-dir ./static-web-app   # from infra/terragrunt/dev
+
+# Grab the hostname and deployment token
+terragrunt output --working-dir ./static-web-app default_host_name
+terragrunt output --raw --working-dir ./static-web-app api_key
+```
+
+### Wire up CI deployment
+
+The `deploy-web-swa.yml` workflow builds the Vite app and deploys it to SWA on
+every push to `main` that touches `web/`. Configure these in GitHub
+(**Settings → Secrets and variables → Actions**):
+
+| Kind | Name | Value |
+|------|------|-------|
+| Secret | `AZURE_STATIC_WEB_APPS_API_TOKEN` | the `api_key` output above |
+| Variable | `VITE_API_URL` | `https://<apigateway-fqdn>` (the ACA gateway) |
+| Variable | `VITE_AUTH_MODE` | `zitadel` |
+| Variable | `VITE_ZITADEL_AUTHORITY` | Zitadel instance URL |
+| Variable | `VITE_ZITADEL_CLIENT_ID` | SPA client ID |
+| Variable | `VITE_ZITADEL_PROJECT_ID` | Zitadel project ID |
+
+### CORS
+
+The gateway allow-lists the SWA origin automatically: the `apigateway` unit reads
+`default_host_name` from the `static-web-app` unit and sets
+`Cors__AllowedOrigins__0=https://<swa-host>`. Re-apply `apigateway` (or let the
+next revision roll) after the SWA exists so the origin takes effect.
+
+### Auth prerequisite (OIDC / Zitadel)
+
+The dashboard is configured for **OIDC via Zitadel**, but Zitadel is **not** part
+of the lean ACA stack (omitted per #375). Until an identity provider is
+provisioned (tracked by the IdentityManager auth issue), login will not complete.
+When Zitadel is available, register the SWA URLs in the SPA client:
+
+- Redirect URI: `https://<swa-host>/callback`
+- Post-logout redirect URI: `https://<swa-host>`
 
 ## Cost controls
 

--- a/infra/terragrunt/dev/aca/README.md
+++ b/infra/terragrunt/dev/aca/README.md
@@ -81,18 +81,16 @@ terragrunt run --all apply --queue-include-dir ./resource-group --queue-include-
   --queue-include-dir ./managed-identity --queue-include-dir ./monitoring \
   --queue-include-dir ./key-vault --queue-include-dir ./postgresql
 
-# Web dashboard host (SWA) — apply before the ACA stack: the apigateway unit
-# reads its hostname to allow-list the dashboard origin for CORS.
-terragrunt apply --working-dir ./static-web-app
-
-# ACA stack
+# ACA stack — includes the Static Web Apps unit (aca/static-web-app). Terragrunt
+# applies it before apigateway, which reads its hostname to allow-list the
+# dashboard origin for CORS.
 terragrunt run --all apply --working-dir ./aca
 ```
 
-> The `apigateway` unit depends on `static-web-app` for its CORS origin. Apply
-> `static-web-app` first (one-time) so `terragrunt run --all ./aca` can resolve
-> the hostname; otherwise the gateway apply fails on the missing dependency
-> output. See [Web dashboard](#web-dashboard-azure-static-web-apps) below.
+> The `static-web-app` unit lives inside `./aca`, so `terragrunt run --all` walks
+> it and orders it ahead of `apigateway` (which depends on its hostname for CORS)
+> automatically — no separate manual apply step. See
+> [Web dashboard](#web-dashboard-azure-static-web-apps) below.
 
 ### Set the GHCR PAT (out-of-band — never in Terraform state)
 
@@ -128,18 +126,18 @@ curl -i https://<apigateway-fqdn>/api/devices   # routed by YARP to DeviceManage
 ## Web dashboard (Azure Static Web Apps)
 
 The React dashboard (`web/`) is hosted on **Azure Static Web Apps (Free)**, giving
-a permanent `https://<name>.azurestaticapps.net` URL (issue #383). SWA is a
-separate unit from the ACA stack — it lives in `infra/terragrunt/dev/static-web-app`
-and is **pinned to West Europe** because the Free tier is not offered in
-northeurope.
+a permanent `https://<name>.azurestaticapps.net` URL (issue #383). The SWA unit
+lives inside the ACA group at `infra/terragrunt/dev/aca/static-web-app` (so it is
+applied and ordered with the rest of the stack) but is **pinned to West Europe**
+because the Free tier is not offered in northeurope.
 
 ```bash
-# Provision the Static Web App (one-time)
-terragrunt apply --working-dir ./static-web-app   # from infra/terragrunt/dev
+# Applied as part of `run --all ./aca`, or on its own:
+terragrunt apply --working-dir ./aca/static-web-app   # from infra/terragrunt/dev
 
 # Grab the hostname and deployment token
-terragrunt output --working-dir ./static-web-app default_host_name
-terragrunt output --raw --working-dir ./static-web-app api_key
+terragrunt output --working-dir ./aca/static-web-app default_host_name
+terragrunt output --raw --working-dir ./aca/static-web-app api_key
 ```
 
 ### Wire up CI deployment

--- a/infra/terragrunt/dev/aca/apigateway/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/apigateway/terragrunt.hcl
@@ -59,7 +59,7 @@ dependency "secrets" {
 
 # The Static Web Apps dashboard origin is allow-listed for CORS on the gateway.
 dependency "static_web_app" {
-  config_path = "../../static-web-app"
+  config_path = "../static-web-app"
 
   mock_outputs = {
     default_host_name = "mock-swa.azurestaticapps.net"

--- a/infra/terragrunt/dev/aca/apigateway/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/apigateway/terragrunt.hcl
@@ -57,6 +57,16 @@ dependency "secrets" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
 }
 
+# The Static Web Apps dashboard origin is allow-listed for CORS on the gateway.
+dependency "static_web_app" {
+  config_path = "../../static-web-app"
+
+  mock_outputs = {
+    default_host_name = "mock-swa.azurestaticapps.net"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
 inputs = {
   name                         = local.name
   resource_group_name          = dependency.resource_group.outputs.name
@@ -82,6 +92,9 @@ inputs = {
   # internal ingress over HTTPS on 443 with a valid cert for *.internal.<domain>.
   env_vars = {
     "ASPNETCORE_HTTP_PORTS" = "8080"
+
+    # Allow the deployed Static Web Apps dashboard origin through CORS.
+    "Cors__AllowedOrigins__0" = "https://${dependency.static_web_app.outputs.default_host_name}"
 
     "ReverseProxy__Clusters__device-manager__Destinations__destination1__Address"      = "https://${local.env.project}-ca-devicemanager-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}"
     "ReverseProxy__Clusters__bundle-orchestrator__Destinations__destination1__Address" = "https://${local.env.project}-ca-bundleorchestrator-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}"

--- a/infra/terragrunt/dev/aca/static-web-app/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/static-web-app/terragrunt.hcl
@@ -3,11 +3,11 @@ include "root" {
 }
 
 terraform {
-  source = "../../../terraform/modules/static-web-app"
+  source = "../../../../terraform/modules/static-web-app"
 }
 
 dependency "resource_group" {
-  config_path = "../resource-group"
+  config_path = "../../resource-group"
 
   mock_outputs = {
     name     = "mock-rg"

--- a/infra/terragrunt/dev/static-web-app/terragrunt.hcl
+++ b/infra/terragrunt/dev/static-web-app/terragrunt.hcl
@@ -1,0 +1,26 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../terraform/modules/static-web-app"
+}
+
+dependency "resource_group" {
+  config_path = "../resource-group"
+
+  mock_outputs = {
+    name     = "mock-rg"
+    id       = "/subscriptions/00000000/resourceGroups/mock-rg"
+    location = "westeurope"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+inputs = {
+  resource_group_name = dependency.resource_group.outputs.name
+
+  # SWA Free tier is not offered in northeurope (where the ACA stack lives).
+  # Pin to West Europe — overrides the env.hcl location for this module only.
+  location = "westeurope"
+}

--- a/src/SignalBeam.ApiGateway/Program.cs
+++ b/src/SignalBeam.ApiGateway/Program.cs
@@ -10,18 +10,34 @@ builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"))
     .AddServiceDiscoveryDestinationResolver();
 
-// Add CORS to allow frontend requests
+// Add CORS to allow frontend requests. Local dev origins are always allowed;
+// deployed origins (e.g. the Azure Static Web Apps dashboard) are supplied via
+// configuration so they can be set per-environment without a code change:
+//   Cors__AllowedOrigins__0 = https://<app>.azurestaticapps.net
+var defaultOrigins = new[]
+{
+    "http://localhost:5173",  // Vite dev server (Aspire proxy)
+    "http://localhost:5174",  // Vite dev server (fallback port)
+    "http://localhost:3000",  // Alternative frontend port
+    "http://localhost:3001",  // Alternative frontend port
+    "http://localhost:4173",  // Vite preview
+};
+
+var configuredOrigins = builder.Configuration
+    .GetSection("Cors:AllowedOrigins")
+    .Get<string[]>() ?? [];
+
+var allowedOrigins = defaultOrigins
+    .Concat(configuredOrigins)
+    .Where(origin => !string.IsNullOrWhiteSpace(origin))
+    .Distinct(StringComparer.OrdinalIgnoreCase)
+    .ToArray();
+
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        policy.WithOrigins(
-                "http://localhost:5173",  // Vite dev server (Aspire proxy)
-                "http://localhost:5174",  // Vite dev server (fallback port)
-                "http://localhost:3000",  // Alternative frontend port
-                "http://localhost:3001",  // Alternative frontend port
-                "http://localhost:4173"   // Vite preview
-            )
+        policy.WithOrigins(allowedOrigins)
             .AllowAnyMethod()
             .AllowAnyHeader()
             .AllowCredentials()

--- a/src/SignalBeam.ApiGateway/Program.cs
+++ b/src/SignalBeam.ApiGateway/Program.cs
@@ -27,6 +27,21 @@ var configuredOrigins = builder.Configuration
     .GetSection("Cors:AllowedOrigins")
     .Get<string[]>() ?? [];
 
+// Fail fast on misconfiguration: a wildcard or malformed origin must never reach
+// the CORS policy (a public SPA origin combined with AllowCredentials makes "*"
+// both invalid and dangerous). Validate before the policy is built.
+var invalidOrigins = configuredOrigins
+    .Where(origin => !string.IsNullOrWhiteSpace(origin))
+    .Where(origin => origin == "*" || !Uri.TryCreate(origin, UriKind.Absolute, out _))
+    .ToArray();
+
+if (invalidOrigins.Length > 0)
+{
+    throw new InvalidOperationException(
+        $"Invalid CORS origins in configuration (Cors:AllowedOrigins): {string.Join(", ", invalidOrigins)}. " +
+        "Origins must be absolute URIs (e.g. https://app.azurestaticapps.net) and must not be '*'.");
+}
+
 var allowedOrigins = defaultOrigins
     .Concat(configuredOrigins)
     .Where(origin => !string.IsNullOrWhiteSpace(origin))

--- a/src/SignalBeam.ApiGateway/appsettings.json
+++ b/src/SignalBeam.ApiGateway/appsettings.json
@@ -7,6 +7,9 @@
     }
   },
   "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": []
+  },
   "ReverseProxy": {
     "Routes": {
       "devices-route": {

--- a/web/public/staticwebapp.config.json
+++ b/web/public/staticwebapp.config.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/staticwebapp.config.json",
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/assets/*", "/*.{css,js,png,jpg,jpeg,svg,ico,json,woff,woff2,webp}"]
+  },
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/index.html",
+      "statusCode": 200
+    }
+  },
+  "globalHeaders": {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin"
+  }
+}

--- a/web/public/staticwebapp.config.json
+++ b/web/public/staticwebapp.config.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/staticwebapp.config.json",
   "navigationFallback": {
     "rewrite": "/index.html",
-    "exclude": ["/assets/*", "/*.{css,js,png,jpg,jpeg,svg,ico,json,woff,woff2,webp}"]
+    "exclude": ["/assets/*", "/*.{css,js,map,png,jpg,jpeg,svg,ico,json,woff,woff2,webp}"]
   },
   "responseOverrides": {
     "404": {
@@ -13,6 +13,8 @@
   "globalHeaders": {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
-    "Referrer-Policy": "strict-origin-when-cross-origin"
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+    "Content-Security-Policy": "default-src 'self'; connect-src 'self' https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
   }
 }


### PR DESCRIPTION
## Summary

Hosts the React dashboard (`web/`) on **Azure Static Web Apps (Free)**, giving a permanent `https://<name>.azurestaticapps.net` URL. Previously the only cloud entry point was the ACA API gateway and the dashboard had to be run locally.

Closes #383

## Changes

**Infrastructure**
- New Terraform module `infra/terraform/modules/static-web-app/` — `azurerm_static_web_app`, Free tier, name follows `{project}-swa-web-{env}-{location_short}` (`sb-swa-web-dev-weu`).
- New Terragrunt unit `infra/terragrunt/dev/aca/static-web-app/` — placed **inside the ACA group** so `terragrunt run --all ./aca` discovers it and orders it ahead of the gateway. **Pinned to West Europe** because the SWA Free tier is not offered in northeurope (where the rest of the stack lives).
- `apigateway` unit gains a dependency on `static-web-app` and sets `Cors__AllowedOrigins__0` to the SWA hostname automatically (no hardcoded host, no secret in state).

**CI**
- New `.github/workflows/deploy-web-swa.yml` — builds the Vite app via the SWA/Oryx action and deploys, with PR preview + close jobs. Kept `build-web.yml` (GHCR image) intact for the Helm/k8s path, per the chosen "separate workflow" approach.

**Backend**
- `SignalBeam.ApiGateway` CORS origins are now config-driven (`Cors:AllowedOrigins`) merged with localhost defaults, with startup validation rejecting `*`/non-absolute origins. Documented the key in `appsettings.json`.

**Frontend**
- `web/public/staticwebapp.config.json` — SPA fallback for React Router, plus security headers (CSP, HSTS, X-Frame-Options, nosniff).

## Auth decision

Configured for **OIDC / Zitadel** (env-driven `VITE_ZITADEL_*` through the workflow), per the chosen auth mode. ⚠️ **Login will not complete until Zitadel is provisioned** — it was omitted from the lean stack (#375). Hosting, build/deploy, CORS, and the URL are all in scope here; standing up the IdP and registering the SWA redirect URIs is a documented follow-up (tracked by the IdentityManager auth issue).

## Manual steps (documented in `infra/terragrunt/dev/aca/README.md`)
1. Apply the stack (or just `./aca/static-web-app`), grab `api_key` + `default_host_name`.
2. Set repo secret `AZURE_STATIC_WEB_APPS_API_TOKEN` and `VITE_*` repo variables.
3. Register the SWA URLs as Zitadel redirect / post-logout URIs once Zitadel exists.

## Test plan / quality gates
- ✅ Backend build (Release) + `dotnet format` clean
- ✅ Backend unit tests pass
- ✅ Frontend `tsc` type-check clean
- ✅ `terraform validate` + `terraform fmt` + `terragrunt hcl format` clean (incl. new sku validation)
- ✅ `helm lint` (6 charts), workflow YAML + config JSON valid
- ⚠️ Pre-existing, unrelated to this PR: integration-test failures in DeviceManager/EdgeAgent (Docker/Testcontainers, rate-limiting flakiness) and 12 ESLint errors in untouched `.tsx` files — not bundled here.

## Review notes (from automated review)
Addressed: cross-scope dependency (moved unit into `./aca/`), naming convention (`location_short`), CORS wildcard validation, HSTS/CSP headers, sku validation, config discoverability, close-job checkout.
Deferred (with rationale): `checkout@v6` flagged as invalid is a **false positive** — the repo standardizes on `@v6` across 5 workflows; `WithExposedHeaders("*")` is **pre-existing** and out of scope for this issue.

## Docs follow-up (advisory)
`docs/architecture.md`, `docs/operations/deployment.md`, and `docs/README.md` reference frontend hosting and should be synced to mention SWA — the primary ACA runbook is already updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)