### PR TITLE
fix zitadel terragrunt locals referencing a dependency output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -411,6 +411,8 @@ AGENTS.md
 infra/terragrunt/**/.terragrunt-cache/
 infra/terragrunt/**/.terragrunt*
 infra/terragrunt/**/.terraform*
+# Provider binaries/locks from running `terraform init` directly in a module dir (e.g. validation)
+infra/terraform/modules/**/.terraform*
 # env.hcl holds the Azure subscription id — copy from env.hcl.example (kept local)
 infra/terragrunt/**/env.hcl
 .zitadel/

--- a/docs/operations/cookbooks/README.md
+++ b/docs/operations/cookbooks/README.md
@@ -1,0 +1,11 @@
+# Operations Cookbooks
+
+Reusable, parameterized recipes for recurring operational tasks. Each is written
+to adapt across environments (`dev` / staging / prod) and, where noted, across
+services — edit the variables block at the top and follow along.
+
+| Cookbook | Use when |
+|----------|----------|
+| [Stateful app with DB migrations on ACA](stateful-app-with-migrations-on-aca.md) | Deploying a service that needs one-shot DB init/migration before it can serve (Zitadel, Keycloak, etc.) on Azure Container Apps — using the init→setup→start job split to avoid migration-race deadlocks |
+
+For full deployment paths (AKS vs ACA) see [`../deployment.md`](../deployment.md).

--- a/docs/operations/cookbooks/stateful-app-with-migrations-on-aca.md
+++ b/docs/operations/cookbooks/stateful-app-with-migrations-on-aca.md
@@ -21,7 +21,7 @@ These follow the repo naming convention `{project}-{kind}-{env}-{loc}`. For a ne
 env, only `ENV` / `LOC` / `SUB` change.
 
 ```bash
-SUB=3fee91b5-7993-40b1-93ba-b76893ff03db   # az subscription id
+SUB=<your-subscription-id>   # az subscription id (e.g. az account show --query id -o tsv)
 ENV=dev
 LOC=northeurope ; LOCSHORT=neu
 PROJECT=sb

--- a/docs/operations/cookbooks/stateful-app-with-migrations-on-aca.md
+++ b/docs/operations/cookbooks/stateful-app-with-migrations-on-aca.md
@@ -1,0 +1,248 @@
+# Cookbook: Deploying a stateful app with DB migrations on Azure Container Apps
+
+A reusable recipe for running a stateful service that needs **one-shot DB
+bootstrap/migration before it can serve** (e.g. Zitadel, Keycloak, or any app
+with a `migrate` step) on the SignalBeam ACA stack — without the migration-race
+deadlocks you hit when the service migrates itself.
+
+**Worked example:** Zitadel (`infra/terragrunt/dev/aca/zitadel*`). Substitute your
+own service throughout.
+
+> Why this pattern: if the long-running service runs migrations at startup, two
+> overlapping replicas during an ACA rolling revision race the same migration and
+> deadlock. Split migration into one-shot **jobs** and let the service do nothing
+> but serve.
+
+---
+
+## 0. Variables (edit per env / service)
+
+These follow the repo naming convention `{project}-{kind}-{env}-{loc}`. For a new
+env, only `ENV` / `LOC` / `SUB` change.
+
+```bash
+SUB=3fee91b5-7993-40b1-93ba-b76893ff03db   # az subscription id
+ENV=dev
+LOC=northeurope ; LOCSHORT=neu
+PROJECT=sb
+SVC=zitadel                                 # your service slug
+
+RG=$PROJECT-rg-$ENV-$LOCSHORT
+CAE=$PROJECT-cae-$ENV-$LOCSHORT             # container apps environment
+KV=$PROJECT-kv-$ENV-$LOCSHORT
+PG=$PROJECT-psql-$ENV-$LOCSHORT
+MI=$PROJECT-id-workload-$ENV-$LOCSHORT      # workload managed identity (has KV Secrets User)
+MI_ID=$(az identity show -g $RG -n $MI --query id -o tsv)
+```
+
+---
+
+## 1. The IaC shape
+
+Three pieces, in dependency order — the canonical **init → setup → start**:
+
+| Unit | Module | Command | Trigger | Purpose |
+|------|--------|---------|---------|---------|
+| `{svc}-init`  | `container-app-job` | `init`  | Manual one-shot | create schema / base tables / DB role |
+| `{svc}-setup` | `container-app-job` | `setup` | Manual one-shot | run migrations + first-time data; depends on init |
+| `{svc}`       | `container-app`     | `start` | always-on (min 1) | serve only — **no migrations** |
+
+Key module choices (see `infra/terraform/modules/container-app-job`):
+
+- **`container-app-job`** wraps `azurerm_container_app_job` — `triggerType: Manual`,
+  `parallelism = 1`, `replicaCompletionCount = 1` (one execution = one replica, so
+  the job can never race itself). Jobs require an explicit `location` (apps don't).
+- The **service** runs `start` only, keeps a normal `readiness_probe_path`
+  (e.g. `/debug/ready`), and `min_replicas = 1` for a stateful app. Because it
+  doesn't migrate, overlapping revisions during a rollout are safe.
+- Secrets are Key Vault references resolved at runtime by the workload identity —
+  values never enter Terraform state.
+
+If your image is **distroless** (no `/bin/sh`), you cannot chain `init && setup` in
+one container — that is exactly why these are three separate one-shots.
+
+---
+
+## 2. Deploy
+
+```bash
+cd infra/terragrunt/dev
+terragrunt run --all apply --working-dir ./aca      # provisions jobs + service in DAG order
+```
+
+`apply` **creates** the jobs but does **not** run them (they're manual-trigger),
+and Terraform cannot reach the private Postgres to grant DB privileges. So the
+bootstrap below is required after apply. The service will crash-loop (harmlessly)
+until the jobs have run.
+
+### 2a. Grant DB privileges (in-VNet, one-shot)
+
+Postgres here is **VNet-private** (`public_network_access_enabled = false`):
+`az postgres ... firewall-rule` is rejected and your workstation cannot reach it.
+Terraform pre-creates the DB owned by `azure_pg_admin`, so the admin role
+(`pgadmin`) lacks `CREATE` and `init` fails. Grant it from a throwaway job that
+runs inside the environment's VNet, pulling the admin password from Key Vault via
+the managed identity.
+
+`dbgrant-job.yaml` (replace `<sub>`, `$SVC` DB name, server host):
+
+```yaml
+location: northeurope
+identity:
+  type: UserAssigned
+  userAssignedIdentities:
+    /subscriptions/<sub>/resourcegroups/sb-rg-dev-neu/providers/Microsoft.ManagedIdentity/userAssignedIdentities/sb-id-workload-dev-neu: {}
+properties:
+  environmentId: /subscriptions/<sub>/resourceGroups/sb-rg-dev-neu/providers/Microsoft.App/managedEnvironments/sb-cae-dev-neu
+  configuration:
+    triggerType: Manual
+    replicaTimeout: 300
+    replicaRetryLimit: 0
+    manualTriggerConfig: { parallelism: 1, replicaCompletionCount: 1 }
+    secrets:
+      - name: pgpw
+        keyVaultUrl: https://sb-kv-dev-neu.vault.azure.net/secrets/postgresql-admin-password
+        identity: /subscriptions/<sub>/resourcegroups/sb-rg-dev-neu/providers/Microsoft.ManagedIdentity/userAssignedIdentities/sb-id-workload-dev-neu
+  template:
+    containers:
+      - name: dbgrant
+        image: postgres:16-alpine
+        resources: { cpu: 0.25, memory: 0.5Gi }
+        env: [{ name: PGPASSWORD, secretRef: pgpw }]
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - >-
+            psql "host=sb-psql-dev-neu.postgres.database.azure.com user=pgadmin dbname=postgres sslmode=require"
+            -c 'ALTER DATABASE zitadel OWNER TO pgadmin;'
+            -c 'GRANT ALL PRIVILEGES ON DATABASE zitadel TO pgadmin;'
+```
+
+```bash
+az containerapp job create --name $PROJECT-caj-dbgrant-$ENV -g $RG --yaml dbgrant-job.yaml
+az containerapp job start  --name $PROJECT-caj-dbgrant-$ENV -g $RG     # logs: ALTER DATABASE / GRANT
+az containerapp job delete --name $PROJECT-caj-dbgrant-$ENV -g $RG --yes
+```
+
+> **Gotcha — `az ... --args "-c"` fails.** The CLI parser treats any value
+> starting with `-` as a flag ("unrecognized arguments: -c ..."). Always pass
+> `command`/`args` as **YAML lists** (as above), or use `az containerapp job
+> update --args` only for non-dash values.
+
+### 2b. Run init → setup → restart
+
+```bash
+# init (wait for Succeeded)
+az containerapp job start --name $PROJECT-caj-$SVC-init-$ENV -g $RG
+az containerapp job execution list --name $PROJECT-caj-$SVC-init-$ENV -g $RG --query "[0].properties.status" -o tsv
+
+# setup (wait for Succeeded)
+az containerapp job start --name $PROJECT-caj-$SVC-setup-$ENV -g $RG
+az containerapp job execution list --name $PROJECT-caj-$SVC-setup-$ENV -g $RG --query "[0].properties.status" -o tsv
+
+# restart the service so `start` picks up the migrated DB
+az containerapp revision restart --name $PROJECT-ca-$SVC-$ENV -g $RG \
+  --revision "$(az containerapp show -n $PROJECT-ca-$SVC-$ENV -g $RG --query properties.latestRevisionName -o tsv)"
+```
+
+### 2c. Verify
+
+```bash
+FQDN=$(terragrunt output --working-dir ./aca/$SVC fqdn | tr -d '"')
+curl -sf "https://$FQDN/debug/ready" && echo OK        # adjust health path per app
+```
+
+---
+
+## 3. Reading job logs (important)
+
+`az containerapp job logs show` only surfaces **stdout**. Many apps (Zitadel
+included) log to **stderr**, so the command looks empty even on failure. Read the
+real logs from Log Analytics:
+
+```bash
+WSID=$(az containerapp env show -n $CAE -g $RG \
+  --query "properties.appLogsConfiguration.logAnalyticsConfiguration.customerId" -o tsv)
+
+az monitor log-analytics query -w "$WSID" --analytics-query \
+  "ContainerAppConsoleLogs_CL | where TimeGenerated > ago(30m)
+   | where ContainerName_s == '$PROJECT-caj-$SVC-setup-$ENV'
+   | project TimeGenerated, Log_s | order by TimeGenerated desc | take 60" -o table
+```
+
+---
+
+## 4. Recovering a stuck migration
+
+If a previous combined `start-from-init` (or any interrupted migrate) crashed
+mid-migration, it can leave a "started but not done" lock and the next run **hangs
+forever**. Symptoms: setup execution stays `Running` with no progress.
+
+1. Stop the stuck execution: `az containerapp job stop -n <job> -g $RG --job-execution-name <exec>`.
+2. Inspect the eventstore (run a read-only psql job): look for `system.migration.started`
+   rows in `eventstore.events2` with no matching `done`.
+3. **Cleanest fix when the DB has no real data:** drop & recreate it, matching
+   Terraform's charset, then re-run init → setup:
+   ```sql
+   DROP DATABASE IF EXISTS <db> WITH (FORCE);
+   CREATE DATABASE <db> OWNER pgadmin TEMPLATE template0
+     ENCODING 'UTF8' LC_COLLATE 'en_US.utf8' LC_CTYPE 'en_US.utf8';
+   ```
+   (Recreating with the same charset/collation avoids Terraform drift.)
+   Deleting just the `started` markers can leave partial DDL that then fails — a
+   clean DB is more reliable when there's nothing to lose.
+
+---
+
+## 5. App-specific gotchas
+
+These are per-app; the Zitadel ones are recorded here because they cost real time:
+
+- **Machine-ID panic (Zitadel):** *"none of the enabled methods for identifying the
+  machine succeeded"*. Zitadel's defaults (Private IP + GCP metadata webhook) both
+  fail on ACA. Set on the service **and** jobs:
+  ```
+  ZITADEL_MACHINE_IDENTIFICATION_HOSTNAME_ENABLED=true
+  ZITADEL_MACHINE_IDENTIFICATION_PRIVATEIP_ENABLED=false
+  ZITADEL_MACHINE_IDENTIFICATION_WEBHOOK_ENABLED=false
+  ```
+  ACA gives each replica a unique hostname (like a K8s pod), so hostname works.
+- **External addressing must match the browser host** or OIDC/issuer validation
+  breaks — set `ZITADEL_EXTERNALDOMAIN` to the predictable ACA FQDN
+  `<app-name>.<env-default-domain>` on both the setup job and the service.
+
+---
+
+## 6. Rebuild reproducibility (`destroy` → `apply`)
+
+`apply` alone does not bootstrap — it provisions; you re-run §2.
+
+- **Postgres survives the destroy** (you only destroyed the ACA app/job units): the
+  DB is already migrated and the master key unchanged, so the recreated service
+  comes up healthy on apply with no manual steps (restart only if it raced).
+- **Postgres is also destroyed** (fresh empty DB): repeat the full §2 bootstrap
+  (grant → init → setup → restart). A fresh DB + proper init→setup order is clean —
+  the stuck-migration case (§4) won't recur.
+
+Cautions:
+- The shared Postgres server also holds the `signalbeam` DB for the other
+  microservices — **don't destroy it casually.**
+- **Master key and DB must stay in sync.** Destroying Key Vault regenerates
+  encryption keys; if the DB survives but the key changes, the app can't decrypt
+  existing data. Keep both, or reset both together.
+
+---
+
+## 7. Make it turnkey (optional)
+
+Terraform can't run manual-trigger jobs, but a post-apply `null_resource` with
+`local-exec` (or a CI step) can call `az containerapp job start` for init/setup and
+then restart the service — turning a fresh deploy into `apply` + one script. The
+DB grant still needs the in-VNet job (§2a) since the runner can't reach private
+Postgres directly.
+
+---
+
+**Related:** `infra/terragrunt/dev/aca/README.md` (live Zitadel runbook),
+`docs/operations/deployment.md` (AKS vs ACA paths).
+```

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -132,3 +132,10 @@ cd infra/terragrunt/dev && terragrunt run --all destroy
 Postgres can also be stopped overnight to halve its cost. Destroying the ACA stack
 removes the NATS JetStream Azure Files share — acceptable for a dogfood, where
 message data is transient.
+
+## Cookbooks
+
+Reusable recipes for recurring operational tasks live in
+[`cookbooks/`](cookbooks/README.md) — e.g. [deploying a stateful app with DB
+migrations on ACA](cookbooks/stateful-app-with-migrations-on-aca.md) (the
+init→setup→start job pattern used by Zitadel).

--- a/infra/terraform/modules/app-secrets/main.tf
+++ b/infra/terraform/modules/app-secrets/main.tf
@@ -35,6 +35,49 @@ resource "azurerm_key_vault_secret" "ghcr_pat" {
   }
 }
 
+# Tenant API key for the MVP/dogfood auth path (X-Api-Key header). Generated
+# strong here and injected into the API-key services (DeviceManager,
+# BundleOrchestrator, IdentityManager) as a Key Vault reference, so the deployed
+# apps never rely on the guessable `dev-api-key-1` placeholders baked into
+# appsettings.json (those remain for LOCAL dev only). The env injection overrides
+# `Authentication:ApiKeys:0` at runtime, so the weak keys are invalid in the cloud
+# even on already-built images.
+#
+# Alphanumeric only (special = false): the key travels in an HTTP header and the
+# validator splits the composite on ':', so the key itself must contain no ':'.
+resource "random_password" "tenant_api_key" {
+  length  = 48
+  special = false
+}
+
+locals {
+  # Server-side tenant id the validator returns for this key. Kept as the existing
+  # dev tenant id so tenant-scoped data created during the dogfood stays addressable.
+  tenant_id = "00000000-0000-0000-0000-000000000001"
+  # All scopes across services in one key — each service only checks the scope its
+  # endpoint needs, so a superset is harmless and lets one dashboard key work
+  # everywhere (the same way the old dev-api-key-1 did).
+  tenant_api_scopes = "devices:read,devices:write,bundles:read,bundles:write,identity:read,identity:write"
+}
+
+# Composite `tenantId:key:scopes` — the exact string the ApiKeyValidator parses.
+# Referenced as `Authentication__ApiKeys__0` by the service apps.
+resource "azurerm_key_vault_secret" "tenant_api_key" {
+  name         = "tenant-api-key"
+  value        = "${local.tenant_id}:${random_password.tenant_api_key.result}:${local.tenant_api_scopes}"
+  key_vault_id = var.key_vault_id
+  tags         = var.tags
+}
+
+# The raw key value on its own — what a human pastes into the dashboard's API-key
+# login. (The composite above is for the services; this is for people.)
+resource "azurerm_key_vault_secret" "tenant_api_key_value" {
+  name         = "tenant-api-key-value"
+  value        = random_password.tenant_api_key.result
+  key_vault_id = var.key_vault_id
+  tags         = var.tags
+}
+
 # Zitadel first-instance admin password. Generated here (not out-of-band) because
 # it only ever seeds the initial admin login at bootstrap; rotate via the Zitadel
 # console afterwards. Complexity satisfies Zitadel's default password policy

--- a/infra/terraform/modules/app-secrets/outputs.tf
+++ b/infra/terraform/modules/app-secrets/outputs.tf
@@ -11,6 +11,11 @@ output "ghcr_pat_secret_id" {
   value       = azurerm_key_vault_secret.ghcr_pat.versionless_id
 }
 
+output "tenant_api_key_secret_id" {
+  description = "Versionless Key Vault secret ID for the tenant API key composite (tenantId:key:scopes); injected as Authentication__ApiKeys__0"
+  value       = azurerm_key_vault_secret.tenant_api_key.versionless_id
+}
+
 # Zitadel secrets. The master key and Postgres admin password are created by the
 # key-vault module; their versionless IDs are built from the vault URI so the
 # Zitadel container app can reference them without a cross-module data source.

--- a/infra/terraform/modules/container-app-job/main.tf
+++ b/infra/terraform/modules/container-app-job/main.tf
@@ -1,0 +1,85 @@
+# Reusable Azure Container App Job — a one-shot, run-to-completion task on the
+# same Container Apps environment as the long-running apps.
+#
+# Designed for bootstrap/migration work (e.g. Zitadel `setup`) that must run
+# exactly once per deploy and finish before the long-running service starts. By
+# moving migrations out of the service and into a Job with parallelism = 1, a
+# rolling service revision can never run two replicas that race the same
+# migration. Mirrors the container-app module for identity, secrets, and
+# registry handling so a service and its migration job share configuration.
+resource "azurerm_container_app_job" "this" {
+  name                         = var.name
+  location                     = var.location
+  resource_group_name          = var.resource_group_name
+  container_app_environment_id = var.container_app_environment_id
+  workload_profile_name        = var.workload_profile_name
+  tags                         = var.tags
+
+  # A job execution is killed if it runs past this; one Zitadel setup is well
+  # under this on a warm DB but the first run does the full schema build.
+  replica_timeout_in_seconds = var.replica_timeout_in_seconds
+  replica_retry_limit        = var.replica_retry_limit
+
+  # Manually triggered: applied by Terraform, then executed on demand via
+  # `az containerapp job start` in the deploy pipeline before the service rolls.
+  # parallelism = 1 + replica_completion_count = 1 means a single execution runs
+  # exactly one replica — so the job can never race itself on the migration.
+  manual_trigger_config {
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [var.managed_identity_id]
+  }
+
+  dynamic "registry" {
+    for_each = var.registry_server == "" ? [] : [1]
+    content {
+      server               = var.registry_server
+      username             = var.registry_username
+      password_secret_name = var.registry_password_secret_name
+    }
+  }
+
+  # Key Vault reference secrets — resolved at runtime by the managed identity.
+  dynamic "secret" {
+    for_each = var.kv_secrets
+    content {
+      name                = secret.value.name
+      key_vault_secret_id = secret.value.key_vault_secret_id
+      identity            = var.managed_identity_id
+    }
+  }
+
+  template {
+    container {
+      name   = var.name
+      image  = var.image
+      cpu    = var.cpu
+      memory = var.memory
+      # Use null (not []) when unset so the image's own entrypoint/CMD is preserved.
+      command = length(var.command) > 0 ? var.command : null
+      args    = length(var.args) > 0 ? var.args : null
+
+      # Plain environment variables
+      dynamic "env" {
+        for_each = var.env_vars
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      # Environment variables sourced from secrets (env name -> secret name)
+      dynamic "env" {
+        for_each = var.secret_env_vars
+        content {
+          name        = env.key
+          secret_name = env.value
+        }
+      }
+    }
+  }
+}

--- a/infra/terraform/modules/container-app-job/outputs.tf
+++ b/infra/terraform/modules/container-app-job/outputs.tf
@@ -1,0 +1,9 @@
+output "id" {
+  description = "Container app job ID"
+  value       = azurerm_container_app_job.this.id
+}
+
+output "name" {
+  description = "Container app job name"
+  value       = azurerm_container_app_job.this.name
+}

--- a/infra/terraform/modules/container-app-job/variables.tf
+++ b/infra/terraform/modules/container-app-job/variables.tf
@@ -1,0 +1,120 @@
+variable "name" {
+  description = "Container app job name (lowercase alphanumeric and hyphens, e.g. sb-caj-zitadel-setup-dev)"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region (Container App Jobs require an explicit location, unlike Container Apps)"
+  type        = string
+}
+
+variable "container_app_environment_id" {
+  description = "ID of the Container Apps environment"
+  type        = string
+}
+
+variable "managed_identity_id" {
+  description = "User-assigned managed identity ID (used for Key Vault references and registry auth)"
+  type        = string
+}
+
+variable "image" {
+  description = "Fully qualified container image, e.g. ghcr.io/zitadel/zitadel:v2.66.3"
+  type        = string
+}
+
+variable "cpu" {
+  description = "vCPU allocation for the container"
+  type        = number
+  default     = 0.5
+}
+
+variable "memory" {
+  description = "Memory allocation for the container (e.g. 1.0Gi)"
+  type        = string
+  default     = "1.0Gi"
+}
+
+variable "command" {
+  description = "Container entrypoint/command override (replaces the image ENTRYPOINT); empty uses the image default"
+  type        = list(string)
+  default     = []
+}
+
+variable "args" {
+  description = "Container args appended to the image ENTRYPOINT (like Docker CMD), e.g. Zitadel's `setup`; empty uses the image default"
+  type        = list(string)
+  default     = []
+}
+
+variable "workload_profile_name" {
+  description = "Workload profile name on the environment"
+  type        = string
+  default     = "Consumption"
+}
+
+variable "replica_timeout_in_seconds" {
+  description = "Maximum time a job replica may run before it is terminated"
+  type        = number
+  default     = 1800
+}
+
+variable "replica_retry_limit" {
+  description = "Number of times to retry a failed replica before the execution fails"
+  type        = number
+  default     = 1
+}
+
+# --- Environment & secrets ---
+
+variable "env_vars" {
+  description = "Plain (non-secret) environment variables"
+  type        = map(string)
+  default     = {}
+}
+
+variable "secret_env_vars" {
+  description = "Environment variables sourced from secrets: map of ENV_NAME => secret_name"
+  type        = map(string)
+  default     = {}
+}
+
+variable "kv_secrets" {
+  description = "Key Vault reference secrets: list of { name, key_vault_secret_id }"
+  type = list(object({
+    name                = string
+    key_vault_secret_id = string
+  }))
+  default = []
+}
+
+# --- Private registry (GHCR) ---
+
+variable "registry_server" {
+  description = "Container registry server (empty to skip, e.g. ghcr.io)"
+  type        = string
+  default     = ""
+}
+
+variable "registry_username" {
+  description = "Container registry username"
+  type        = string
+  default     = ""
+}
+
+variable "registry_password_secret_name" {
+  description = "Name of the secret (in kv_secrets) holding the registry password/PAT"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/container-app/main.tf
+++ b/infra/terraform/modules/container-app/main.tf
@@ -62,6 +62,7 @@ resource "azurerm_container_app" "this" {
       memory = var.memory
       # Use null (not []) when unset so the image's own entrypoint/CMD is preserved.
       command = length(var.command) > 0 ? var.command : null
+      args    = length(var.args) > 0 ? var.args : null
 
       # Plain environment variables
       dynamic "env" {

--- a/infra/terraform/modules/container-app/variables.tf
+++ b/infra/terraform/modules/container-app/variables.tf
@@ -36,7 +36,13 @@ variable "memory" {
 }
 
 variable "command" {
-  description = "Container entrypoint/command override (e.g. NATS JetStream flags); empty uses the image default"
+  description = "Container entrypoint/command override (replaces the image ENTRYPOINT, e.g. NATS JetStream flags); empty uses the image default"
+  type        = list(string)
+  default     = []
+}
+
+variable "args" {
+  description = "Container args appended to the image ENTRYPOINT (like Docker CMD). Use this — not command — when the entrypoint is a binary and you pass a subcommand (e.g. Zitadel's `start-from-init`); empty uses the image default"
   type        = list(string)
   default     = []
 }

--- a/infra/terragrunt/dev/aca/README.md
+++ b/infra/terragrunt/dev/aca/README.md
@@ -70,6 +70,22 @@ it is set out-of-band (below) and never touches state.
    (`apigateway`, `devicemanager`, `bundleorchestrator`, `telemetryprocessor`,
    `identitymanager`).
 5. A GitHub PAT with `read:packages` for pulling private GHCR images.
+6. **Allowlist your IP on the Key Vault firewall.** The vault (`sb-kv-dev-neu`) is
+   `Deny`-by-default with `bypass = AzureServices`, so the Azure CLI is *not* a
+   trusted caller — applying the `key-vault`/`secrets` units from your machine
+   fails with `403 ForbiddenByFirewall` until your public IP is allowed:
+
+   ```bash
+   # the 403 error prints your "Client address" — use that IP
+   az keyvault network-rule add --name sb-kv-dev-neu --ip-address <your-ip>
+   az keyvault network-rule list --name sb-kv-dev-neu -o jsonc   # verify (~30–60s to propagate)
+   ```
+
+   The KV module has `ignore_changes` on `ip_rules`, so this manual rule persists
+   and a later `apply` won't revert it. Re-add if your ISP IP changes. The runtime
+   path is unaffected (container apps reach KV via managed identity, not your IP).
+   **Don't Ctrl-C a terragrunt run** mid-apply on this stack — it can orphan the
+   state lock.
 
 ## Deploy
 

--- a/infra/terragrunt/dev/aca/README.md
+++ b/infra/terragrunt/dev/aca/README.md
@@ -17,6 +17,7 @@ a public HTTPS endpoint the EdgeAgent can reach via `--cloud-url`.
 | `bundleorchestrator` | BundleOrchestrator | internal HTTPS | 0→1 | scale-to-zero |
 | `telemetryprocessor` | TelemetryProcessor | internal HTTPS | 0→1 | scale-to-zero |
 | `identitymanager` | IdentityManager | internal HTTPS | 0→1 | scale-to-zero |
+| `zitadel-init` | Zitadel DB init — eventstore schema + base tables (Container App **Job**) | — | one-shot | Runs `zitadel init`; must complete before `zitadel-setup` |
 | `zitadel-setup` | Zitadel migrations + first-instance bootstrap (Container App **Job**) | — | one-shot | Runs `zitadel setup` to completion; keeps migrations out of the service |
 | `zitadel` | Zitadel OIDC provider | **external HTTPS** | **1** (always-on) | Runs `zitadel start` (no migrations); OIDC for the dashboard + IdentityManager; reuses the shared Postgres (#389) |
 
@@ -204,14 +205,25 @@ services talk to Zitadel **directly** at its own FQDN — not through the gatewa
 which avoids proxying Zitadel's gRPC APIs through YARP. `ZITADEL_EXTERNALDOMAIN` is
 set to that FQDN so issuer/discovery URLs match what the browser uses.
 
-**Migrations are split into a one-shot job.** The `zitadel-setup` Container App
-Job runs `zitadel setup` (schema/migrations + first instance) to completion, and
-the `zitadel` service runs `zitadel start` with **no** migrations. This is the fix
-for the `start-from-init` migration-race deadlock: because the service no longer
-migrates, overlapping replicas during an ACA rolling revision can never race the
-`03_default_instance` migration — so the service keeps a normal readiness probe
-and the old revision retires cleanly. The setup job (`parallelism = 1`) is
-idempotent, so re-running it on an up-to-date DB is a no-op.
+**Bootstrap is split into two one-shot jobs.** Zitadel's lifecycle is layered —
+`init` (create eventstore schema + base tables + app role) → `setup` (migrations +
+first instance) → `start` (serve). The old `start-from-init` ran all three in one
+process and raced itself on the `03_default_instance` migration. Here:
+
+- `zitadel-init` Container App Job runs `zitadel init`
+- `zitadel-setup` Container App Job runs `zitadel setup` (depends on init)
+- the `zitadel` service runs `zitadel start` with **no** migrations
+
+Because the service never migrates, overlapping replicas during an ACA rolling
+revision can never race the migration — so the service keeps a normal readiness
+probe and the old revision retires cleanly. Both jobs are `parallelism = 1` and
+idempotent, so re-running them on an already-bootstrapped DB is a no-op.
+
+The units also set **hostname-based machine identification**
+(`ZITADEL_MACHINE_IDENTIFICATION_HOSTNAME_ENABLED=true`, Private-IP + webhook
+disabled). Zitadel's defaults (Private IP + GCP metadata) both fail on ACA and
+panic with *"none of the enabled methods for identifying the machine succeeded"*;
+ACA gives each replica a unique hostname (like a K8s pod), which works.
 
 ```bash
 # FQDN + first-instance admin password
@@ -220,45 +232,90 @@ az keyvault secret show --vault-name sb-kv-dev-neu --name zitadel-admin-password
 # Admin console: https://<zitadel-fqdn>  (user: admin, pw: the secret above)
 ```
 
-### Prerequisite — grant DB ownership (run once, before the setup job runs)
+### Prerequisite — grant DB privileges (run once, before the init job)
 
-Terraform pre-creates the `zitadel` database, so it is **not** owned by `pgadmin`
-(the server admin). The `zitadel setup` job runs DDL (CREATE SCHEMA/ROLE/GRANT)
-and needs ownership, or it fails. Grant it once, out-of-band (same pattern as
-running EF migrations — from a VNet-connected host or with your IP temporarily
-allowed):
+Terraform pre-creates the `zitadel` database owned by `azure_pg_admin`, so
+`pgadmin` lacks CREATE on it and `zitadel init` (CREATE SCHEMA/ROLE) fails. The
+Postgres server is **private (VNet-only, no public endpoint)** — firewall rules
+are rejected and you cannot reach it from a workstation. Run the grant from an
+in-VNet one-shot job instead (admin password pulled from Key Vault via the
+workload managed identity — nothing sensitive on your machine, no KV firewall
+change). Save as `dbgrant-job.yaml`:
 
-```bash
-PGPASSWORD=$(az keyvault secret show --vault-name sb-kv-dev-neu \
-  --name postgresql-admin-password --query value -o tsv) \
-psql "host=sb-psql-dev-neu.postgres.database.azure.com user=pgadmin dbname=postgres sslmode=require" \
-  -c 'ALTER DATABASE zitadel OWNER TO pgadmin;' \
-  -c 'GRANT ALL PRIVILEGES ON DATABASE zitadel TO pgadmin;'
+```yaml
+location: northeurope
+identity:
+  type: UserAssigned
+  userAssignedIdentities:
+    /subscriptions/<sub>/resourcegroups/sb-rg-dev-neu/providers/Microsoft.ManagedIdentity/userAssignedIdentities/sb-id-workload-dev-neu: {}
+properties:
+  environmentId: /subscriptions/<sub>/resourceGroups/sb-rg-dev-neu/providers/Microsoft.App/managedEnvironments/sb-cae-dev-neu
+  configuration:
+    triggerType: Manual
+    replicaTimeout: 300
+    replicaRetryLimit: 0
+    manualTriggerConfig: { parallelism: 1, replicaCompletionCount: 1 }
+    secrets:
+      - name: pgpw
+        keyVaultUrl: https://sb-kv-dev-neu.vault.azure.net/secrets/postgresql-admin-password
+        identity: /subscriptions/<sub>/resourcegroups/sb-rg-dev-neu/providers/Microsoft.ManagedIdentity/userAssignedIdentities/sb-id-workload-dev-neu
+  template:
+    containers:
+      - name: dbgrant
+        image: postgres:16-alpine
+        resources: { cpu: 0.25, memory: 0.5Gi }
+        env: [{ name: PGPASSWORD, secretRef: pgpw }]
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - >-
+            psql "host=sb-psql-dev-neu.postgres.database.azure.com user=pgadmin dbname=postgres sslmode=require"
+            -c 'ALTER DATABASE zitadel OWNER TO pgadmin;'
+            -c 'GRANT ALL PRIVILEGES ON DATABASE zitadel TO pgadmin;'
 ```
 
-### Deploy order — run the setup job, then the service
-
-`terragrunt run --all apply` creates both the job and the service (the `zitadel`
-unit depends on `zitadel-setup`, so the job is created first). The job is
-**manually triggered**, so after apply, run it to completion before the service
-can serve, then restart the service to pick up the migrated schema:
-
 ```bash
-RG=$(terragrunt output --working-dir ./aca/resource-group name | tr -d '"')
-JOB=$(terragrunt output --working-dir ./aca/zitadel-setup name | tr -d '"')
-
-# Run migrations + create the first instance, and wait for it to finish
-az containerapp job start --name "$JOB" -g "$RG"
-az containerapp job execution list --name "$JOB" -g "$RG" \
-  --query "[0].properties.status" -o tsv   # → "Succeeded"
-
-# Then (re)start the service so `zitadel start` runs against the migrated DB
-az containerapp revision restart --name sb-ca-zitadel-dev -g "$RG" \
-  --revision "$(az containerapp show -n sb-ca-zitadel-dev -g "$RG" --query properties.latestRevisionName -o tsv)"
+RG=sb-rg-dev-neu
+az containerapp job create --name sb-caj-dbgrant-dev -g $RG --yaml dbgrant-job.yaml
+az containerapp job start  --name sb-caj-dbgrant-dev -g $RG   # logs should show ALTER DATABASE / GRANT
+az containerapp job delete --name sb-caj-dbgrant-dev -g $RG --yes
 ```
 
-Re-run the job before any future Zitadel image upgrade that ships new migrations;
-it is idempotent on an already-migrated DB.
+> Pass `command`/`args` via YAML, not `az ... --args "-c"` — the CLI parser
+> rejects values that start with `-`.
+
+### Deploy order — init → setup → service
+
+`terragrunt run --all apply` creates the two jobs and the service in dependency
+order (`zitadel` → `zitadel-setup` → `zitadel-init`). The jobs are **manually
+triggered**, so after apply, run them in order, then restart the service:
+
+```bash
+RG=sb-rg-dev-neu
+
+# 1) init — eventstore schema + base tables (wait for Succeeded)
+az containerapp job start --name sb-caj-zitadel-init-dev -g $RG
+az containerapp job execution list --name sb-caj-zitadel-init-dev -g $RG --query "[0].properties.status" -o tsv
+
+# 2) setup — migrations + first instance (wait for Succeeded)
+az containerapp job start --name sb-caj-zitadel-setup-dev -g $RG
+az containerapp job execution list --name sb-caj-zitadel-setup-dev -g $RG --query "[0].properties.status" -o tsv
+
+# 3) restart the service so `zitadel start` runs against the migrated DB
+az containerapp revision restart --name sb-ca-zitadel-dev -g $RG \
+  --revision "$(az containerapp show -n sb-ca-zitadel-dev -g $RG --query properties.latestRevisionName -o tsv)"
+
+# verify
+curl -sf "https://$(terragrunt output --working-dir ./aca/zitadel fqdn | tr -d '"')/debug/ready" && echo OK
+```
+
+> **Note on job logs:** Zitadel writes to stderr, which `az containerapp job logs
+> show` does not surface — it appears empty. To see real errors, query Log
+> Analytics: `ContainerAppConsoleLogs_CL | where ContainerName_s ==
+> 'sb-caj-zitadel-setup-dev'`.
+
+Re-run init + setup before any future Zitadel image upgrade that ships new
+migrations; both are idempotent on an already-bootstrapped DB.
 
 ### One-time bootstrap (project + SPA client)
 

--- a/infra/terragrunt/dev/aca/README.md
+++ b/infra/terragrunt/dev/aca/README.md
@@ -17,7 +17,8 @@ a public HTTPS endpoint the EdgeAgent can reach via `--cloud-url`.
 | `bundleorchestrator` | BundleOrchestrator | internal HTTPS | 0→1 | scale-to-zero |
 | `telemetryprocessor` | TelemetryProcessor | internal HTTPS | 0→1 | scale-to-zero |
 | `identitymanager` | IdentityManager | internal HTTPS | 0→1 | scale-to-zero |
-| `zitadel` | Zitadel OIDC provider | **external HTTPS** | **1** (always-on) | OIDC for the dashboard + IdentityManager; reuses the shared Postgres (#389) |
+| `zitadel-setup` | Zitadel migrations + first-instance bootstrap (Container App **Job**) | — | one-shot | Runs `zitadel setup` to completion; keeps migrations out of the service |
+| `zitadel` | Zitadel OIDC provider | **external HTTPS** | **1** (always-on) | Runs `zitadel start` (no migrations); OIDC for the dashboard + IdentityManager; reuses the shared Postgres (#389) |
 
 **Omitted for the lean dogfood:** Valkey (confirmed unused — caching is in-process
 `IMemoryCache`), ACR (images come from private GHCR). See issue #375 for the full
@@ -203,6 +204,15 @@ services talk to Zitadel **directly** at its own FQDN — not through the gatewa
 which avoids proxying Zitadel's gRPC APIs through YARP. `ZITADEL_EXTERNALDOMAIN` is
 set to that FQDN so issuer/discovery URLs match what the browser uses.
 
+**Migrations are split into a one-shot job.** The `zitadel-setup` Container App
+Job runs `zitadel setup` (schema/migrations + first instance) to completion, and
+the `zitadel` service runs `zitadel start` with **no** migrations. This is the fix
+for the `start-from-init` migration-race deadlock: because the service no longer
+migrates, overlapping replicas during an ACA rolling revision can never race the
+`03_default_instance` migration — so the service keeps a normal readiness probe
+and the old revision retires cleanly. The setup job (`parallelism = 1`) is
+idempotent, so re-running it on an up-to-date DB is a no-op.
+
 ```bash
 # FQDN + first-instance admin password
 terragrunt output --working-dir ./aca/zitadel fqdn
@@ -210,13 +220,13 @@ az keyvault secret show --vault-name sb-kv-dev-neu --name zitadel-admin-password
 # Admin console: https://<zitadel-fqdn>  (user: admin, pw: the secret above)
 ```
 
-### Prerequisite — grant DB ownership (run once, before Zitadel first boots)
+### Prerequisite — grant DB ownership (run once, before the setup job runs)
 
 Terraform pre-creates the `zitadel` database, so it is **not** owned by `pgadmin`
-(the server admin). Zitadel's `start-from-init` runs DDL (CREATE SCHEMA/ROLE/GRANT)
-and needs ownership, or it crash-loops on first boot. Grant it once, out-of-band
-(same pattern as running EF migrations — from a VNet-connected host or with your IP
-temporarily allowed):
+(the server admin). The `zitadel setup` job runs DDL (CREATE SCHEMA/ROLE/GRANT)
+and needs ownership, or it fails. Grant it once, out-of-band (same pattern as
+running EF migrations — from a VNet-connected host or with your IP temporarily
+allowed):
 
 ```bash
 PGPASSWORD=$(az keyvault secret show --vault-name sb-kv-dev-neu \
@@ -226,13 +236,34 @@ psql "host=sb-psql-dev-neu.postgres.database.azure.com user=pgadmin dbname=postg
   -c 'GRANT ALL PRIVILEGES ON DATABASE zitadel TO pgadmin;'
 ```
 
-Then start (or restart) the `zitadel` app so `start-from-init` runs against the
-now-owned database.
+### Deploy order — run the setup job, then the service
+
+`terragrunt run --all apply` creates both the job and the service (the `zitadel`
+unit depends on `zitadel-setup`, so the job is created first). The job is
+**manually triggered**, so after apply, run it to completion before the service
+can serve, then restart the service to pick up the migrated schema:
+
+```bash
+RG=$(terragrunt output --working-dir ./aca/resource-group name | tr -d '"')
+JOB=$(terragrunt output --working-dir ./aca/zitadel-setup name | tr -d '"')
+
+# Run migrations + create the first instance, and wait for it to finish
+az containerapp job start --name "$JOB" -g "$RG"
+az containerapp job execution list --name "$JOB" -g "$RG" \
+  --query "[0].properties.status" -o tsv   # → "Succeeded"
+
+# Then (re)start the service so `zitadel start` runs against the migrated DB
+az containerapp revision restart --name sb-ca-zitadel-dev -g "$RG" \
+  --revision "$(az containerapp show -n sb-ca-zitadel-dev -g "$RG" --query properties.latestRevisionName -o tsv)"
+```
+
+Re-run the job before any future Zitadel image upgrade that ships new migrations;
+it is idempotent on an already-migrated DB.
 
 ### One-time bootstrap (project + SPA client)
 
-`start-from-init` + the `ZITADEL_FIRSTINSTANCE_*` env vars create the instance and
-admin on first boot, but the **SignalBeam project + OIDC SPA app** must be created
+The `zitadel setup` job + the `ZITADEL_FIRSTINSTANCE_*` env vars create the
+instance and admin, but the **SignalBeam project + OIDC SPA app** must be created
 once. Use the `SignalBeam.ZitadelSetup` tool (now parameterised for the deployed
 host) — create a service user + PAT in the Zitadel console first, then:
 

--- a/infra/terragrunt/dev/aca/bundleorchestrator/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/bundleorchestrator/terragrunt.hcl
@@ -51,8 +51,9 @@ dependency "secrets" {
   config_path = "../secrets"
 
   mock_outputs = {
-    db_connection_secret_id = "https://mock-kv.vault.azure.net/secrets/db-connection-signalbeam"
-    ghcr_pat_secret_id      = "https://mock-kv.vault.azure.net/secrets/ghcr-pat"
+    db_connection_secret_id  = "https://mock-kv.vault.azure.net/secrets/db-connection-signalbeam"
+    ghcr_pat_secret_id       = "https://mock-kv.vault.azure.net/secrets/ghcr-pat"
+    tenant_api_key_secret_id = "https://mock-kv.vault.azure.net/secrets/tenant-api-key"
   }
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
 }
@@ -76,14 +77,20 @@ inputs = {
   kv_secrets = [
     { name = "ghcr-pat", key_vault_secret_id = dependency.secrets.outputs.ghcr_pat_secret_id },
     { name = "db-conn", key_vault_secret_id = dependency.secrets.outputs.db_connection_secret_id },
+    { name = "tenant-api-key", key_vault_secret_id = dependency.secrets.outputs.tenant_api_key_secret_id },
   ]
 
   secret_env_vars = {
     "ConnectionStrings__signalbeam" = "db-conn"
+    # Strong tenant API key from Key Vault — overrides the guessable dev-api-key-1
+    # baked into appsettings.json (Authentication:ApiKeys:0).
+    "Authentication__ApiKeys__0" = "tenant-api-key"
   }
 
   env_vars = {
     "ASPNETCORE_HTTP_PORTS" = "8080"
-    "NATS__Url"             = "nats://${local.env.project}-ca-nats-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}:4222"
+    # Neutralize the second baked dev key (dev-api-key-2 at index 1).
+    "Authentication__ApiKeys__1" = ""
+    "NATS__Url"                  = "nats://${local.env.project}-ca-nats-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}:4222"
   }
 }

--- a/infra/terragrunt/dev/aca/devicemanager/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/devicemanager/terragrunt.hcl
@@ -51,8 +51,9 @@ dependency "secrets" {
   config_path = "../secrets"
 
   mock_outputs = {
-    db_connection_secret_id = "https://mock-kv.vault.azure.net/secrets/db-connection-signalbeam"
-    ghcr_pat_secret_id      = "https://mock-kv.vault.azure.net/secrets/ghcr-pat"
+    db_connection_secret_id  = "https://mock-kv.vault.azure.net/secrets/db-connection-signalbeam"
+    ghcr_pat_secret_id       = "https://mock-kv.vault.azure.net/secrets/ghcr-pat"
+    tenant_api_key_secret_id = "https://mock-kv.vault.azure.net/secrets/tenant-api-key"
   }
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
 }
@@ -76,15 +77,23 @@ inputs = {
   kv_secrets = [
     { name = "ghcr-pat", key_vault_secret_id = dependency.secrets.outputs.ghcr_pat_secret_id },
     { name = "db-conn", key_vault_secret_id = dependency.secrets.outputs.db_connection_secret_id },
+    { name = "tenant-api-key", key_vault_secret_id = dependency.secrets.outputs.tenant_api_key_secret_id },
   ]
 
   secret_env_vars = {
     "ConnectionStrings__signalbeam" = "db-conn"
+    # Strong tenant API key from Key Vault — overrides the guessable dev-api-key-1
+    # baked into appsettings.json (Authentication:ApiKeys:0) so it's invalid in the
+    # cloud even on already-built images.
+    "Authentication__ApiKeys__0" = "tenant-api-key"
   }
 
   env_vars = {
-    "ASPNETCORE_HTTP_PORTS"    = "8080"
-    "NATS__Url"                = "nats://${local.env.project}-ca-nats-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}:4222"
-    "IdentityManager__BaseUrl" = "https://${local.env.project}-ca-identitymanager-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}"
+    "ASPNETCORE_HTTP_PORTS" = "8080"
+    # Neutralize the second baked dev key (dev-api-key-2 at index 1): an empty
+    # entry is skipped by the validator. Remove once images ship without dev keys.
+    "Authentication__ApiKeys__1" = ""
+    "NATS__Url"                  = "nats://${local.env.project}-ca-nats-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}:4222"
+    "IdentityManager__BaseUrl"   = "https://${local.env.project}-ca-identitymanager-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}"
   }
 }

--- a/infra/terragrunt/dev/aca/identitymanager/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/identitymanager/terragrunt.hcl
@@ -51,8 +51,9 @@ dependency "secrets" {
   config_path = "../secrets"
 
   mock_outputs = {
-    db_connection_secret_id = "https://mock-kv.vault.azure.net/secrets/db-connection-signalbeam"
-    ghcr_pat_secret_id      = "https://mock-kv.vault.azure.net/secrets/ghcr-pat"
+    db_connection_secret_id  = "https://mock-kv.vault.azure.net/secrets/db-connection-signalbeam"
+    ghcr_pat_secret_id       = "https://mock-kv.vault.azure.net/secrets/ghcr-pat"
+    tenant_api_key_secret_id = "https://mock-kv.vault.azure.net/secrets/tenant-api-key"
   }
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
 }
@@ -76,15 +77,21 @@ inputs = {
   kv_secrets = [
     { name = "ghcr-pat", key_vault_secret_id = dependency.secrets.outputs.ghcr_pat_secret_id },
     { name = "db-conn", key_vault_secret_id = dependency.secrets.outputs.db_connection_secret_id },
+    { name = "tenant-api-key", key_vault_secret_id = dependency.secrets.outputs.tenant_api_key_secret_id },
   ]
 
   secret_env_vars = {
     "ConnectionStrings__signalbeam" = "db-conn"
+    # Strong tenant API key from Key Vault — overrides the guessable dev-api-key-1
+    # baked into appsettings.json (Authentication:ApiKeys:0).
+    "Authentication__ApiKeys__0" = "tenant-api-key"
   }
 
   env_vars = {
     "ASPNETCORE_HTTP_PORTS" = "8080"
-    "NATS__Url"             = "nats://${local.env.project}-ca-nats-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}:4222"
+    # Neutralize the second baked dev key (dev-api-key-2 at index 1).
+    "Authentication__ApiKeys__1" = ""
+    "NATS__Url"                  = "nats://${local.env.project}-ca-nats-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}:4222"
 
     # OIDC issuer = the deployed Zitadel external FQDN (must match the token issuer
     # so ValidateIssuer passes). HTTPS metadata is required in the deployed env.

--- a/infra/terragrunt/dev/aca/zitadel-init/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/zitadel-init/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 
 locals {
   env  = read_terragrunt_config(find_in_parent_folders("env.hcl")).locals
-  name = "${local.env.project}-caj-zitadel-setup-${local.env.environment}"
+  name = "${local.env.project}-caj-zitadel-init-${local.env.environment}"
 }
 
 terraform {
@@ -72,20 +72,6 @@ dependency "secrets" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
 }
 
-# Init job. Declaring it orders the `run --all` DAG so the eventstore-creating
-# `zitadel init` job is created before this setup job. init must also be EXECUTED
-# to completion before setup is run (see this unit's args comment) — `setup`
-# fails with "relation eventstore.events does not exist" otherwise.
-dependency "zitadel_init" {
-  config_path = "../zitadel-init"
-
-  mock_outputs = {
-    id   = "/subscriptions/00000000/resourceGroups/mock-rg/providers/Microsoft.App/jobs/mock-caj-init"
-    name = "mock-caj-zitadel-init"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
-}
-
 inputs = {
   name                         = local.name
   location                     = local.env.location
@@ -93,35 +79,32 @@ inputs = {
   container_app_environment_id = dependency.environment.outputs.id
   managed_identity_id          = dependency.managed_identity.outputs.id
 
-  # Same pinned image as the zitadel service so the schema the job builds matches
-  # exactly what `zitadel start` expects.
+  # Same pinned image as the setup job + service.
   image = "ghcr.io/zitadel/zitadel:v2.66.3"
 
-  # `setup` runs DB migrations AND creates the first instance, then exits. It
-  # REQUIRES the `zitadel-init` job to have run first (init creates the eventstore
-  # schema + base tables setup migrates); without it setup dies with "relation
-  # eventstore.events does not exist". This is the ONLY place migrations run — the
-  # zitadel service runs `start` with no migrations, so overlapping service
-  # revisions during a rollout can never race the 03_default_instance migration.
-  # Bootstrap order: run zitadel-init to completion, then run this job, then
-  # (re)start the service. It is idempotent — re-running on a migrated DB is a
-  # no-op. --masterkeyFromEnv reads the 32-char master key from ZITADEL_MASTERKEY.
-  args = ["setup", "--masterkeyFromEnv"]
+  # `init` creates the eventstore schema, the base `eventstore.events`/`events2`
+  # tables, and the application DB role — the foundation that `zitadel setup`
+  # (migrations) and `zitadel start` both REQUIRE. Zitadel's own commands are
+  # layered: init -> setup -> start (the old `start-from-init` did all three in
+  # one process). Because the image is distroless, the three phases can't be
+  # chained in one container, so init is its own one-shot job that must run to
+  # completion BEFORE the setup job:
+  #   az containerapp job start --name <this job> -g <rg>   # wait for Succeeded
+  # It is idempotent — re-running against an initialized DB is a no-op.
+  args = ["init"]
 
   cpu    = 0.5
   memory = "1.0Gi"
 
+  # init connects as the Postgres admin to create the schema + the application
+  # role (whose password it sets from the user secret).
   kv_secrets = [
-    { name = "zitadel-master-key", key_vault_secret_id = dependency.secrets.outputs.zitadel_master_key_secret_id },
     { name = "zitadel-db-password", key_vault_secret_id = dependency.secrets.outputs.postgres_admin_password_secret_id },
-    { name = "zitadel-admin-password", key_vault_secret_id = dependency.secrets.outputs.zitadel_admin_password_secret_id },
   ]
 
   secret_env_vars = {
-    "ZITADEL_MASTERKEY"                        = "zitadel-master-key"
     "ZITADEL_DATABASE_POSTGRES_USER_PASSWORD"  = "zitadel-db-password"
     "ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD" = "zitadel-db-password"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD" = "zitadel-admin-password"
   }
 
   env_vars = {
@@ -133,28 +116,5 @@ inputs = {
     "ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE"  = "require"
     "ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME" = "pgadmin"
     "ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE" = "require"
-
-    # --- External addressing — must match the service so the issuer the first
-    # instance is created with equals the browser-facing host. ---
-    "ZITADEL_EXTERNALSECURE" = "true"
-    "ZITADEL_EXTERNALDOMAIN" = "${local.env.project}-ca-zitadel-${local.env.environment}.${dependency.environment.outputs.default_domain}"
-    "ZITADEL_EXTERNALPORT"   = "443"
-
-    # --- Machine ID (sonyflake) identification ---
-    # `setup` also generates sonyflake IDs (first instance/org/user), so it hits
-    # the same machine-ID panic as the service on ACA. Use hostname identification
-    # and disable the Private-IP + GCP-webhook methods that fail here. Must match
-    # the service's setting (see the zitadel unit for the full rationale).
-    "ZITADEL_MACHINE_IDENTIFICATION_HOSTNAME_ENABLED"  = "true"
-    "ZITADEL_MACHINE_IDENTIFICATION_PRIVATEIP_ENABLED" = "false"
-    "ZITADEL_MACHINE_IDENTIFICATION_WEBHOOK_ENABLED"   = "false"
-
-    # --- First-instance bootstrap: human admin (created during setup) ---
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME"               = "admin"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORDCHANGEREQUIRED" = "false"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_ADDRESS"          = "admin@signalbeam.local"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_VERIFIED"         = "true"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_FIRSTNAME"              = "SignalBeam"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_LASTNAME"               = "Admin"
   }
 }

--- a/infra/terragrunt/dev/aca/zitadel-setup/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/zitadel-setup/terragrunt.hcl
@@ -1,0 +1,135 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+locals {
+  env  = read_terragrunt_config(find_in_parent_folders("env.hcl")).locals
+  name = "${local.env.project}-caj-zitadel-setup-${local.env.environment}"
+}
+
+terraform {
+  source = "../../../../terraform/modules/container-app-job"
+}
+
+dependency "resource_group" {
+  config_path = "../../resource-group"
+
+  mock_outputs = {
+    name     = "mock-rg"
+    id       = "/subscriptions/00000000/resourceGroups/mock-rg"
+    location = "northeurope"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "managed_identity" {
+  config_path = "../../managed-identity"
+
+  mock_outputs = {
+    id           = "/subscriptions/00000000/resourceGroups/mock-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mock-id"
+    principal_id = "00000000-0000-0000-0000-000000000000"
+    client_id    = "00000000-0000-0000-0000-000000000000"
+    name         = "mock-id"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "environment" {
+  config_path = "../environment"
+
+  mock_outputs = {
+    id                = "/subscriptions/00000000/resourceGroups/mock-rg/providers/Microsoft.App/managedEnvironments/mock-cae"
+    name              = "mock-cae"
+    default_domain    = "mockenv.northeurope.azurecontainerapps.io"
+    static_ip_address = "20.0.0.1"
+    nats_storage_name = "nats-jetstream"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "postgresql" {
+  config_path = "../../postgresql"
+
+  mock_outputs = {
+    id             = "/subscriptions/00000000/resourceGroups/mock-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/mock-psql"
+    name           = "mock-psql"
+    fqdn           = "mock-psql.postgres.database.azure.com"
+    database_names = ["signalbeam", "zitadel"]
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "secrets" {
+  config_path = "../secrets"
+
+  mock_outputs = {
+    db_connection_secret_id           = "https://mock-kv.vault.azure.net/secrets/db-connection-signalbeam"
+    ghcr_pat_secret_id                = "https://mock-kv.vault.azure.net/secrets/ghcr-pat"
+    zitadel_master_key_secret_id      = "https://mock-kv.vault.azure.net/secrets/zitadel-master-key"
+    postgres_admin_password_secret_id = "https://mock-kv.vault.azure.net/secrets/postgresql-admin-password"
+    zitadel_admin_password_secret_id  = "https://mock-kv.vault.azure.net/secrets/zitadel-admin-password"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+inputs = {
+  name                         = local.name
+  location                     = local.env.location
+  resource_group_name          = dependency.resource_group.outputs.name
+  container_app_environment_id = dependency.environment.outputs.id
+  managed_identity_id          = dependency.managed_identity.outputs.id
+
+  # Same pinned image as the zitadel service so the schema the job builds matches
+  # exactly what `zitadel start` expects.
+  image = "ghcr.io/zitadel/zitadel:v2.66.3"
+
+  # `setup` runs DB schema/migrations AND creates the first instance, then exits.
+  # This is the ONLY place migrations run — the zitadel service runs `start` with
+  # no migrations, so overlapping service revisions during a rollout can never
+  # race the 03_default_instance migration. Run this job to completion (via
+  # `az containerapp job start --name <name> -g <rg>`) before deploying/restarting
+  # the zitadel service. It is idempotent, so re-running on an up-to-date DB is a
+  # no-op. --masterkeyFromEnv reads the 32-char master key from ZITADEL_MASTERKEY.
+  args = ["setup", "--masterkeyFromEnv"]
+
+  cpu    = 0.5
+  memory = "1.0Gi"
+
+  kv_secrets = [
+    { name = "zitadel-master-key", key_vault_secret_id = dependency.secrets.outputs.zitadel_master_key_secret_id },
+    { name = "zitadel-db-password", key_vault_secret_id = dependency.secrets.outputs.postgres_admin_password_secret_id },
+    { name = "zitadel-admin-password", key_vault_secret_id = dependency.secrets.outputs.zitadel_admin_password_secret_id },
+  ]
+
+  secret_env_vars = {
+    "ZITADEL_MASTERKEY"                        = "zitadel-master-key"
+    "ZITADEL_DATABASE_POSTGRES_USER_PASSWORD"  = "zitadel-db-password"
+    "ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD" = "zitadel-db-password"
+    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD" = "zitadel-admin-password"
+  }
+
+  env_vars = {
+    # --- Database (shared Postgres Flexible Server, dedicated `zitadel` DB) ---
+    "ZITADEL_DATABASE_POSTGRES_HOST"           = dependency.postgresql.outputs.fqdn
+    "ZITADEL_DATABASE_POSTGRES_PORT"           = "5432"
+    "ZITADEL_DATABASE_POSTGRES_DATABASE"       = "zitadel"
+    "ZITADEL_DATABASE_POSTGRES_USER_USERNAME"  = "pgadmin"
+    "ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE"  = "require"
+    "ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME" = "pgadmin"
+    "ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE" = "require"
+
+    # --- External addressing — must match the service so the issuer the first
+    # instance is created with equals the browser-facing host. ---
+    "ZITADEL_EXTERNALSECURE" = "true"
+    "ZITADEL_EXTERNALDOMAIN" = "${local.env.project}-ca-zitadel-${local.env.environment}.${dependency.environment.outputs.default_domain}"
+    "ZITADEL_EXTERNALPORT"   = "443"
+
+    # --- First-instance bootstrap: human admin (created during setup) ---
+    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME"               = "admin"
+    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORDCHANGEREQUIRED" = "false"
+    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_ADDRESS"          = "admin@signalbeam.local"
+    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_VERIFIED"         = "true"
+    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_FIRSTNAME"              = "SignalBeam"
+    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_LASTNAME"               = "Admin"
+  }
+}

--- a/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
@@ -164,5 +164,16 @@ inputs = {
     "ZITADEL_EXTERNALSECURE" = "true"
     "ZITADEL_EXTERNALDOMAIN" = "${local.name}.${dependency.environment.outputs.default_domain}"
     "ZITADEL_EXTERNALPORT"   = "443"
+
+    # --- Machine ID (sonyflake) identification ---
+    # Zitadel derives a per-machine sonyflake ID at startup. Its defaults
+    # (Private IP + GCP-metadata webhook) BOTH fail on ACA — the container has no
+    # private IP Zitadel can read and there's no GCP metadata server — so it
+    # panics: "none of the enabled methods for identifying the machine
+    # succeeded". ACA gives each replica a unique hostname (like a K8s pod), so
+    # switch to hostname identification and disable the two failing methods.
+    "ZITADEL_MACHINE_IDENTIFICATION_HOSTNAME_ENABLED"  = "true"
+    "ZITADEL_MACHINE_IDENTIFICATION_PRIVATEIP_ENABLED" = "false"
+    "ZITADEL_MACHINE_IDENTIFICATION_WEBHOOK_ENABLED"   = "false"
   }
 }

--- a/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
@@ -92,7 +92,11 @@ inputs = {
   # and "start-from-init" is a subcommand of it. Using `command` would override
   # the entrypoint and try to exec "start-from-init" as a standalone executable
   # (which fails: "executable file not found in $PATH").
-  args = ["start-from-init", "--tlsMode", "disabled"]
+  #
+  # --masterkeyFromEnv tells Zitadel to read the master key from the
+  # ZITADEL_MASTERKEY env var (wired below as a KV secret). Without this flag it
+  # only checks --masterkey/--masterkeyFile and panics "No master key provided".
+  args = ["start-from-init", "--masterkeyFromEnv", "--tlsMode", "disabled"]
 
   # Zitadel is stateful at startup and behaves poorly with scale-to-zero cold
   # starts (it must stay reachable for token/JWKS validation by other services).
@@ -123,7 +127,8 @@ inputs = {
   ]
 
   # Secret-sourced env vars. Master key is passed via env (not the --masterkey
-  # arg) to avoid shell-quoting issues with special characters.
+  # arg) to avoid shell-quoting issues with special characters — requires the
+  # --masterkeyFromEnv flag in args above for Zitadel to actually read it.
   secret_env_vars = {
     "ZITADEL_MASTERKEY"                        = "zitadel-master-key"
     "ZITADEL_DATABASE_POSTGRES_USER_PASSWORD"  = "zitadel-db-password"

--- a/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
@@ -113,12 +113,20 @@ inputs = {
   transport        = "http2"
   target_port      = 8080
 
-  # Readiness-only on purpose: Zitadel's first-run migrations can take 1–2 min,
-  # which exceeds the module's fixed liveness initial_delay and would restart-loop
-  # the container. A failing readiness probe only withholds traffic (no restart),
-  # which is exactly the right behaviour during init. /debug/ready is Zitadel's
-  # readiness endpoint (the setup scripts poll it).
-  readiness_probe_path = "/debug/ready"
+  # NO probes on purpose. start-from-init runs DB migrations BEFORE the HTTP
+  # server starts, so /debug/ready stays down for ~1–2 min on first boot. With a
+  # readiness probe, ACA never marks the new revision "ready", so in single
+  # revision mode it never retires the OLD revision — every redeploy then leaves
+  # another Zitadel replica running, and multiple replicas racing start-from-init
+  # deadlock on the 03_default_instance migration ("migration already started").
+  # Dropping the probe lets a new revision go active immediately and the old one
+  # retire, so exactly one Zitadel runs the migration. (No liveness either — the
+  # process doesn't self-exit, and we don't want restarts mid-migration.)
+  #
+  # NOTE: the proper long-term fix is to split init into a one-shot `zitadel
+  # setup` Job and run `zitadel start` (no migrations) as the service, so
+  # overlapping replicas during a rollout can never race the migration.
+  readiness_probe_path = ""
 
   kv_secrets = [
     { name = "zitadel-master-key", key_vault_secret_id = dependency.secrets.outputs.zitadel_master_key_secret_id },

--- a/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
@@ -74,6 +74,20 @@ dependency "secrets" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
 }
 
+# Migration/bootstrap job. Declaring it here orders the `terragrunt run --all`
+# DAG so the schema-building `zitadel setup` job is created before this service.
+# The job still has to be EXECUTED (`az containerapp job start`) and finish
+# before this service can serve — see this unit's args comment.
+dependency "zitadel_setup" {
+  config_path = "../zitadel-setup"
+
+  mock_outputs = {
+    id   = "/subscriptions/00000000/resourceGroups/mock-rg/providers/Microsoft.App/jobs/mock-caj"
+    name = "mock-caj-zitadel-setup"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
 inputs = {
   name                         = local.name
   resource_group_name          = dependency.resource_group.outputs.name
@@ -84,19 +98,16 @@ inputs = {
   # version used by the Aspire AppHost for local dev, so behaviour is reproducible.
   image = "ghcr.io/zitadel/zitadel:v2.66.3"
 
-  # start-from-init runs DB setup/migrations then starts, in one idempotent
-  # process. TLS is terminated by the ACA Envoy ingress, so Zitadel serves plain
-  # HTTP (h2c) internally.
-  #
-  # These are ARGS, not command: the image ENTRYPOINT is the /app/zitadel binary
-  # and "start-from-init" is a subcommand of it. Using `command` would override
-  # the entrypoint and try to exec "start-from-init" as a standalone executable
-  # (which fails: "executable file not found in $PATH").
-  #
-  # --masterkeyFromEnv tells Zitadel to read the master key from the
-  # ZITADEL_MASTERKEY env var (wired below as a KV secret). Without this flag it
-  # only checks --masterkey/--masterkeyFile and panics "No master key provided".
-  args = ["start-from-init", "--masterkeyFromEnv", "--tlsMode", "disabled"]
+  # `start` ONLY runs the long-running HTTP server — it does NOT run migrations.
+  # All schema/migration + first-instance work is done by the separate
+  # `zitadel-setup` Container App Job (args = ["setup"]), which must finish before
+  # this service is deployed/restarted. Because the service no longer migrates,
+  # overlapping replicas during an ACA rolling revision can never race the
+  # 03_default_instance migration — which is the deadlock the combined
+  # `start-from-init` used to cause. TLS is terminated by the ACA Envoy ingress,
+  # so Zitadel serves plain HTTP (h2c) internally (--tlsMode disabled).
+  # --masterkeyFromEnv reads the 32-char master key from the ZITADEL_MASTERKEY env var.
+  args = ["start", "--masterkeyFromEnv", "--tlsMode", "disabled"]
 
   # Zitadel is stateful at startup and behaves poorly with scale-to-zero cold
   # starts (it must stay reachable for token/JWKS validation by other services).
@@ -113,62 +124,45 @@ inputs = {
   transport        = "http2"
   target_port      = 8080
 
-  # NO probes on purpose. start-from-init runs DB migrations BEFORE the HTTP
-  # server starts, so /debug/ready stays down for ~1–2 min on first boot. With a
-  # readiness probe, ACA never marks the new revision "ready", so in single
-  # revision mode it never retires the OLD revision — every redeploy then leaves
-  # another Zitadel replica running, and multiple replicas racing start-from-init
-  # deadlock on the 03_default_instance migration ("migration already started").
-  # Dropping the probe lets a new revision go active immediately and the old one
-  # retire, so exactly one Zitadel runs the migration. (No liveness either — the
-  # process doesn't self-exit, and we don't want restarts mid-migration.)
-  #
-  # NOTE: the proper long-term fix is to split init into a one-shot `zitadel
-  # setup` Job and run `zitadel start` (no migrations) as the service, so
-  # overlapping replicas during a rollout can never race the migration.
-  readiness_probe_path = ""
+  # With migrations moved to the `zitadel-setup` job, `start` brings the HTTP
+  # server up quickly (no multi-minute migration before /debug/ready), so a
+  # readiness probe is safe again: the new revision reports ready within the
+  # normal window and the old one retires cleanly. This also lets ACA route
+  # traffic only once Zitadel can actually serve token/JWKS validation.
+  readiness_probe_path = "/debug/ready"
 
+  # `start` connects as the application (user) role only — DB/role creation and
+  # the admin connection live in the setup job, so no admin password here.
   kv_secrets = [
     { name = "zitadel-master-key", key_vault_secret_id = dependency.secrets.outputs.zitadel_master_key_secret_id },
     { name = "zitadel-db-password", key_vault_secret_id = dependency.secrets.outputs.postgres_admin_password_secret_id },
-    { name = "zitadel-admin-password", key_vault_secret_id = dependency.secrets.outputs.zitadel_admin_password_secret_id },
   ]
 
   # Secret-sourced env vars. Master key is passed via env (not the --masterkey
   # arg) to avoid shell-quoting issues with special characters — requires the
   # --masterkeyFromEnv flag in args above for Zitadel to actually read it.
   secret_env_vars = {
-    "ZITADEL_MASTERKEY"                        = "zitadel-master-key"
-    "ZITADEL_DATABASE_POSTGRES_USER_PASSWORD"  = "zitadel-db-password"
-    "ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD" = "zitadel-db-password"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD" = "zitadel-admin-password"
+    "ZITADEL_MASTERKEY"                       = "zitadel-master-key"
+    "ZITADEL_DATABASE_POSTGRES_USER_PASSWORD" = "zitadel-db-password"
   }
 
   env_vars = {
     # --- Database (shared Postgres Flexible Server, dedicated `zitadel` DB) ---
-    "ZITADEL_DATABASE_POSTGRES_HOST"           = dependency.postgresql.outputs.fqdn
-    "ZITADEL_DATABASE_POSTGRES_PORT"           = "5432"
-    "ZITADEL_DATABASE_POSTGRES_DATABASE"       = "zitadel"
-    "ZITADEL_DATABASE_POSTGRES_USER_USERNAME"  = "pgadmin"
-    "ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE"  = "require"
-    "ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME" = "pgadmin"
-    "ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE" = "require"
+    # User (application) connection only — admin connection is used by the setup job.
+    "ZITADEL_DATABASE_POSTGRES_HOST"          = dependency.postgresql.outputs.fqdn
+    "ZITADEL_DATABASE_POSTGRES_PORT"          = "5432"
+    "ZITADEL_DATABASE_POSTGRES_DATABASE"      = "zitadel"
+    "ZITADEL_DATABASE_POSTGRES_USER_USERNAME" = "pgadmin"
+    "ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE" = "require"
 
     # --- External addressing (issuer/discovery host) ---
     # ACA assigns an external app the FQDN "<name>.<env-default-domain>" (internal
     # apps get "<name>.internal.<...>"), predictable before the app exists — so
     # EXTERNALDOMAIN is set without a self-referential output. It MUST equal the
-    # browser-facing host or OIDC discovery + JWT issuer validation break.
+    # browser-facing host AND the value the setup job used, or OIDC discovery +
+    # JWT issuer validation break.
     "ZITADEL_EXTERNALSECURE" = "true"
     "ZITADEL_EXTERNALDOMAIN" = "${local.name}.${dependency.environment.outputs.default_domain}"
     "ZITADEL_EXTERNALPORT"   = "443"
-
-    # --- First-instance bootstrap: human admin (login works on first boot) ---
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME"               = "admin"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORDCHANGEREQUIRED" = "false"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_ADDRESS"          = "admin@signalbeam.local"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_VERIFIED"         = "true"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_FIRSTNAME"              = "SignalBeam"
-    "ZITADEL_FIRSTINSTANCE_ORG_HUMAN_LASTNAME"               = "Admin"
   }
 }

--- a/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
@@ -5,14 +5,8 @@ include "root" {
 locals {
   env  = read_terragrunt_config(find_in_parent_folders("env.hcl")).locals
   name = "${local.env.project}-ca-zitadel-${local.env.environment}"
-
-  # ACA assigns an external app the FQDN "<name>.<env-default-domain>" (internal
-  # apps get "<name>.internal.<...>"). This is predictable before the app exists,
-  # so we can set Zitadel's EXTERNALDOMAIN without a self-referential output —
-  # which matters because Zitadel bakes this host into issuer/discovery URLs and
-  # it MUST equal the host the browser uses, or OIDC discovery + JWT issuer
-  # validation break.
-  external_domain = "${local.name}.${dependency.environment.outputs.default_domain}"
+  # The external FQDN is computed inline in env_vars below — a locals block can
+  # only reference other locals, not dependency outputs.
 }
 
 terraform {
@@ -143,8 +137,12 @@ inputs = {
     "ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE" = "require"
 
     # --- External addressing (issuer/discovery host) ---
+    # ACA assigns an external app the FQDN "<name>.<env-default-domain>" (internal
+    # apps get "<name>.internal.<...>"), predictable before the app exists — so
+    # EXTERNALDOMAIN is set without a self-referential output. It MUST equal the
+    # browser-facing host or OIDC discovery + JWT issuer validation break.
     "ZITADEL_EXTERNALSECURE" = "true"
-    "ZITADEL_EXTERNALDOMAIN" = local.external_domain
+    "ZITADEL_EXTERNALDOMAIN" = "${local.name}.${dependency.environment.outputs.default_domain}"
     "ZITADEL_EXTERNALPORT"   = "443"
 
     # --- First-instance bootstrap: human admin (login works on first boot) ---

--- a/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
@@ -87,7 +87,12 @@ inputs = {
   # start-from-init runs DB setup/migrations then starts, in one idempotent
   # process. TLS is terminated by the ACA Envoy ingress, so Zitadel serves plain
   # HTTP (h2c) internally.
-  command = ["start-from-init", "--tlsMode", "disabled"]
+  #
+  # These are ARGS, not command: the image ENTRYPOINT is the /app/zitadel binary
+  # and "start-from-init" is a subcommand of it. Using `command` would override
+  # the entrypoint and try to exec "start-from-init" as a standalone executable
+  # (which fails: "executable file not found in $PATH").
+  args = ["start-from-init", "--tlsMode", "disabled"]
 
   # Zitadel is stateful at startup and behaves poorly with scale-to-zero cold
   # starts (it must stay reachable for token/JWKS validation by other services).

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/appsettings.json
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/appsettings.json
@@ -15,12 +15,9 @@
       "Authority": "https://login.microsoftonline.com/your-tenant-id/v2.0",
       "_Comment_Audience": "Removed hardcoded audience - now read dynamically from ZITADEL_CONFIG_PATH at runtime",
       "RequireHttpsMetadata": true
-    },
-    "ApiKeys": [
-      "00000000-0000-0000-0000-000000000001:dev-api-key-1:bundles:read,bundles:write",
-      "00000000-0000-0000-0000-000000000002:dev-api-key-2:bundles:read"
-    ]
+    }
   },
+  "_Comment_ApiKeys": "Tenant API keys are NOT defined here — deployed envs inject a strong key from Key Vault as Authentication__ApiKeys__0. Local dev keys live in appsettings.Development.json only.",
   "AzureBlobStorage": {
     "ServiceUri": "https://signalbeam.blob.core.windows.net",
     "ContainerName": "signalbeam-bundles",

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/appsettings.Development.json
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Authentication": {
+    "ApiKeys": [
+      "00000000-0000-0000-0000-000000000001:dev-api-key-1:devices:read,devices:write",
+      "00000000-0000-0000-0000-000000000002:dev-api-key-2:devices:read"
+    ]
   }
 }

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/appsettings.json
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/appsettings.json
@@ -26,12 +26,9 @@
       "Authority": "https://login.microsoftonline.com/your-tenant-id/v2.0",
       "_Comment_Audience": "Removed hardcoded audience - now read dynamically from ZITADEL_CONFIG_PATH at runtime",
       "RequireHttpsMetadata": false
-    },
-    "ApiKeys": [
-      "00000000-0000-0000-0000-000000000001:dev-api-key-1:devices:read,devices:write",
-      "00000000-0000-0000-0000-000000000002:dev-api-key-2:devices:read"
-    ]
+    }
   },
+  "_Comment_ApiKeys": "Tenant API keys are NOT defined here — deployed envs inject a strong key from Key Vault as Authentication__ApiKeys__0. Local dev keys live in appsettings.Development.json only.",
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console"

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/appsettings.Development.json
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/appsettings.Development.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Authentication": {
+    "ApiKeys": [
+      "00000000-0000-0000-0000-000000000001:dev-api-key-1:identity:read,identity:write",
+      "00000000-0000-0000-0000-000000000002:dev-api-key-2:identity:read"
+    ]
+  }
+}

--- a/src/IdentityManager/SignalBeam.IdentityManager.Host/appsettings.json
+++ b/src/IdentityManager/SignalBeam.IdentityManager.Host/appsettings.json
@@ -20,6 +20,7 @@
       "RequireHttpsMetadata": false
     }
   },
+  "_Comment_ApiKeys": "Tenant API keys are NOT defined here — deployed envs inject a strong key from Key Vault as Authentication__ApiKeys__0. Local dev keys live in appsettings.Development.json only.",
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console"


### PR DESCRIPTION
## Summary

Follow-up to #395. `terragrunt run --all apply` fails on the `zitadel` unit:

```
Error: Can't evaluate expression … "dependency" is not defined
  on ./zitadel/terragrunt.hcl line 15, in locals:
  external_domain = "${local.name}.${dependency.environment.outputs.default_domain}"
```

A Terragrunt `locals` block can only reference other locals — not `dependency.*` outputs. The fix computes the external FQDN **inline in `env_vars`** (where dependency outputs are valid), matching the existing `apigateway`/`identitymanager` units.

Also documents the **Key Vault firewall IP-allowlist** step in the deploy prerequisites (applying the `key-vault`/`secrets` units from a workstation otherwise 403s with `ForbiddenByFirewall`).

## Why #395's checks didn't catch it
`terraform validate` (modules) and `terragrunt hcl format` both passed — neither evaluates Terragrunt dependency wiring. Only an actual `run --all`/plan surfaces it. Verified the fix removes all `dependency` references from `locals` and that hclfmt is clean.

## Test plan
- ✅ No `dependency.*` left in the `locals` block; `ZITADEL_EXTERNALDOMAIN` computed inline
- ✅ `terragrunt hcl format --check` clean
- ⏳ Confirm with `terragrunt run --all apply --working-dir ./aca` (the original failing command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)