### PR TITLE
fix zitadel console CSP error: use --tlsMode external not disabled

### DIFF
--- a/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/zitadel/terragrunt.hcl
@@ -104,10 +104,18 @@ inputs = {
   # this service is deployed/restarted. Because the service no longer migrates,
   # overlapping replicas during an ACA rolling revision can never race the
   # 03_default_instance migration — which is the deadlock the combined
-  # `start-from-init` used to cause. TLS is terminated by the ACA Envoy ingress,
-  # so Zitadel serves plain HTTP (h2c) internally (--tlsMode disabled).
+  # `start-from-init` used to cause.
+  #
+  # --tlsMode external (NOT disabled): TLS is terminated by the ACA Envoy ingress,
+  # so Zitadel serves plain HTTP internally — but `external` tells Zitadel the
+  # EXTERNAL scheme is https and to trust X-Forwarded-Proto. With `disabled`,
+  # Zitadel builds the console's `environment.json` `api` URL from the (plain http)
+  # request scheme, so it emits http:// while the issuer is https:// — the console
+  # (loaded over https) then violates its own CSP (`connect-src` matches the host
+  # on https only) when it calls the http api. `external` makes the api URL https
+  # and consistent. (ExternalSecure=true alone only fixes the issuer, not the api.)
   # --masterkeyFromEnv reads the 32-char master key from the ZITADEL_MASTERKEY env var.
-  args = ["start", "--masterkeyFromEnv", "--tlsMode", "disabled"]
+  args = ["start", "--masterkeyFromEnv", "--tlsMode", "external"]
 
   # Zitadel is stateful at startup and behaves poorly with scale-to-zero cold
   # starts (it must stay reachable for token/JWKS validation by other services).


### PR DESCRIPTION
## Problem

Logging into the Zitadel console failed with:

```
Connecting to '<URL>' violates the following Content Security Policy directive:
"connect-src 'self' sb-ca-zitadel-dev.whitesea-...azurecontainerapps.io"
```

The console's generated `environment.json` had a **scheme split**:

```json
{"api":"http://sb-ca-zitadel-dev...","issuer":"https://sb-ca-zitadel-dev..."}
```

The console is served over HTTPS, and Zitadel's `connect-src` CSP allows the bare host — which on an HTTPS page matches **HTTPS only**. When the console called its `api` over `http://`, CSP blocked it (scheme mismatch + mixed content), breaking login.

## Cause

The service ran with `--tlsMode disabled`, which tells Zitadel "no TLS anywhere", so it builds the console `api` URL from the plain-HTTP request scheme (ACA Envoy → container is h2c). `ExternalSecure=true` fixes the *issuer*, but the console `api` follows the request scheme, not `ExternalSecure` — hence the http/https split.

## Fix

Use `--tlsMode external`: TLS is terminated upstream by ACA's Envoy ingress, and `external` tells Zitadel to trust `X-Forwarded-Proto: https` and emit HTTPS external URLs. The console `api` URL becomes `https`, consistent with the issuer, and CSP no longer blocks it.

## Verification (live, dev ACA)

- `environment.json` `api` flipped `http://` → `https://` (matches `issuer`)
- `/debug/ready` → 200, console → 200
- Service applied to `sb-ca-zitadel-dev`

Relates to #389 (Zitadel on ACA) and unblocks the console login needed for #419 (OIDC SPA bootstrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)