### PR TITLE
wire backend services' JWT bearer to Zitadel (#419)

### DIFF
--- a/infra/terragrunt/dev/aca/bundleorchestrator/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/bundleorchestrator/terragrunt.hcl
@@ -92,5 +92,14 @@ inputs = {
     # Neutralize the second baked dev key (dev-api-key-2 at index 1).
     "Authentication__ApiKeys__1" = ""
     "NATS__Url"                  = "nats://${local.env.project}-ca-nats-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}:4222"
+
+    # --- OIDC / JWT (Zitadel) ---
+    # The dashboard calls this service through the gateway with a Zitadel access
+    # token. Authority = Zitadel external FQDN (= token issuer); Audience = the
+    # Zitadel project ID the SPA requests as an aud scope. ValidateAudience is on,
+    # so without these JWT validation rejects every token.
+    "Authentication__Jwt__Authority"            = "https://${local.env.project}-ca-zitadel-${local.env.environment}.${dependency.environment.outputs.default_domain}"
+    "Authentication__Jwt__RequireHttpsMetadata" = "true"
+    "Authentication__Jwt__Audience"             = "378987614071444272"
   }
 }

--- a/infra/terragrunt/dev/aca/devicemanager/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/devicemanager/terragrunt.hcl
@@ -95,5 +95,16 @@ inputs = {
     "Authentication__ApiKeys__1" = ""
     "NATS__Url"                  = "nats://${local.env.project}-ca-nats-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}:4222"
     "IdentityManager__BaseUrl"   = "https://${local.env.project}-ca-identitymanager-${local.env.environment}.internal.${dependency.environment.outputs.default_domain}"
+
+    # --- OIDC / JWT (Zitadel) ---
+    # The dashboard authenticates via Zitadel OIDC and calls this service through
+    # the gateway with the Zitadel access token. Authority = the Zitadel external
+    # FQDN (must equal the token issuer). Audience = the Zitadel project ID — the
+    # SPA requests the `urn:zitadel:iam:org:project:id:<projectId>:aud` scope, so
+    # the token's aud carries the project id, and this service validates it
+    # (ValidateAudience is on). Without these, JWT validation rejects every token.
+    "Authentication__Jwt__Authority"            = "https://${local.env.project}-ca-zitadel-${local.env.environment}.${dependency.environment.outputs.default_domain}"
+    "Authentication__Jwt__RequireHttpsMetadata" = "true"
+    "Authentication__Jwt__Audience"             = "378987614071444272"
   }
 }

--- a/infra/terragrunt/dev/aca/identitymanager/terragrunt.hcl
+++ b/infra/terragrunt/dev/aca/identitymanager/terragrunt.hcl
@@ -98,11 +98,10 @@ inputs = {
     "Authentication__Jwt__Authority"            = "https://${local.env.project}-ca-zitadel-${local.env.environment}.${dependency.environment.outputs.default_domain}"
     "Authentication__Jwt__RequireHttpsMetadata" = "true"
 
-    # Authentication__Jwt__Audience is intentionally NOT set here: the audience is
-    # the Zitadel project ID, which only exists after the one-time bootstrap
-    # (see aca/README.md). Set it out-of-band once known to enable audience
-    # validation:
-    #   az containerapp update -n <identitymanager-app> -g <rg> \
-    #     --set-env-vars Authentication__Jwt__Audience=<project-id>
+    # Audience = the Zitadel project ID created by the one-time SignalBeam.ZitadelSetup
+    # bootstrap (#419). The SPA requests `urn:zitadel:iam:org:project:id:<id>:aud`, so
+    # tokens carry the project id as aud; setting it here turns on audience validation
+    # (it was disabled while empty). Same value as DeviceManager/BundleOrchestrator.
+    "Authentication__Jwt__Audience" = "378987614071444272"
   }
 }


### PR DESCRIPTION
## What

Point each backend service's JWT bearer at Zitadel so the dashboard's OIDC access tokens validate when calling the API through the gateway. Completes the backend half of #419 (the SPA/login half is already live).

Per service (terragrunt `env_vars`, no code change — services already read `Authentication:Jwt:*`):
- `Authentication__Jwt__Authority` = Zitadel external FQDN (= token issuer)
- `Authentication__Jwt__Audience` = `378987614071444272` (SignalBeam Edge project id; the SPA requests `urn:zitadel:iam:org:project:id:<id>:aud`)
- `Authentication__Jwt__RequireHttpsMetadata` = `true`

`DeviceManager` and `BundleOrchestrator` previously had **no** Authority (defaulting to the Entra placeholder in appsettings) → they would reject Zitadel tokens. `IdentityManager` already had the authority and now gets the audience so audience validation is enforced (it was off while empty).

## Verification

- Applied to dev ACA; all three revisions **Healthy**.
- Deployed env confirmed on all three (Authority/Audience/RequireHttpsMetadata).

## ⚠️ Found during verification — pre-existing auth bypass (separate issue)

`GET /api/devices` through the **public** gateway returns `200` + tenant JSON for **any** bearer token (e.g. `eyJ…bogus`); only no-auth gets `401`. DeviceManager's "JWT Bearer passthrough" lets unvalidated tokens reach endpoints that don't enforce authorization. This is **not** caused by this change (the old unreachable Entra authority returned 200 too), but it means JWT validation isn't actually gating these endpoints yet. Tracking separately — needs `RequireAuthorization` enforcement / rejecting invalid bearers across the API endpoints.

Relates to #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)