### PR TITLE
fix bearer-token auth bypass: validate JWT in auth middleware (#422)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -425,3 +425,6 @@ tools/workflow-engine/node_modules/
 
 # External plugin repo (not part of this project)
 cloudstack-ai-plugins/
+
+# Playwright MCP run artifacts
+.playwright-mcp/

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/ApiKeyAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/ApiKeyAuthenticationMiddleware.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -36,11 +37,31 @@ public class ApiKeyAuthenticationMiddleware
             return;
         }
 
-        // If request has a Bearer token, skip API key auth and let JWT auth handle it
+        // If the request carries a Bearer token, validate it via the JWT scheme and
+        // reject it when validation fails. Previously any Bearer value was passed
+        // through unvalidated, letting a caller with a bogus token reach endpoints
+        // that don't separately enforce authorization (see #422). AuthenticateAsync
+        // runs the JWT handler and only sets the principal on success.
         var authHeader = context.Request.Headers.Authorization.ToString();
         if (authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
         {
-            await _next(context);
+            var jwtResult = await context.AuthenticateAsync(AuthenticationConstants.JwtBearerScheme);
+            if (jwtResult.Succeeded && jwtResult.Principal is not null)
+            {
+                context.User = jwtResult.Principal;
+                await _next(context);
+                return;
+            }
+
+            _logger.LogWarning(
+                "Bearer token authentication failed: {Failure}",
+                jwtResult.Failure?.Message);
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsJsonAsync(new
+            {
+                error = "invalid_token",
+                message = "The provided bearer token is invalid or has expired."
+            });
             return;
         }
 

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -77,11 +78,30 @@ public class DeviceAuthenticationMiddleware
                 certResult.Error?.Message);
         }
 
-        // [2] If request has a Bearer token, skip this middleware and let JWT auth handle it
+        // [2] If the request carries a Bearer token, validate it via the JWT scheme.
+        // A token that fails validation (bad signature, wrong issuer/audience, or
+        // expired) MUST be rejected here. Previously any Bearer value was passed
+        // through unvalidated, so a caller with a bogus token reached endpoints that
+        // don't separately enforce authorization — returning tenant data
+        // unauthenticated (see #422). AuthenticateAsync runs the JWT handler and
+        // only sets the principal on success.
         var authHeader = context.Request.Headers.Authorization.ToString();
         if (authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
         {
-            await _next(context);
+            var jwtResult = await context.AuthenticateAsync(AuthenticationConstants.JwtBearerScheme);
+            if (jwtResult.Succeeded && jwtResult.Principal is not null)
+            {
+                context.User = jwtResult.Principal;
+                await _next(context);
+                return;
+            }
+
+            _logger.LogWarning(
+                "Bearer token authentication failed: {Failure}",
+                jwtResult.Failure?.Message);
+            await RespondUnauthorized(context,
+                "INVALID_TOKEN",
+                "The provided bearer token is invalid or has expired.");
             return;
         }
 

--- a/tests/SignalBeam.Shared.Infrastructure.Tests/Authentication/BearerValidationTests.cs
+++ b/tests/SignalBeam.Shared.Infrastructure.Tests/Authentication/BearerValidationTests.cs
@@ -1,0 +1,112 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SignalBeam.Shared.Infrastructure.Authentication;
+
+namespace SignalBeam.Shared.Infrastructure.Tests.Authentication;
+
+/// <summary>
+/// Regression tests for #422: the device/api-key middlewares used to pass ANY
+/// bearer token straight through, so a caller with a bogus token reached
+/// endpoints that don't separately enforce authorization. The middlewares must now
+/// validate the bearer via the JWT scheme and reject it when validation fails.
+/// </summary>
+public class BearerValidationTests
+{
+    private static HttpContext BuildContext(AuthenticateResult bearerResult, out bool[] nextCalledRef)
+    {
+        var authService = new Mock<IAuthenticationService>();
+        authService
+            .Setup(s => s.AuthenticateAsync(It.IsAny<HttpContext>(), AuthenticationConstants.JwtBearerScheme))
+            .ReturnsAsync(bearerResult);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(authService.Object);
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        context.Request.Path = "/api/devices";
+        context.Request.Headers.Authorization = "Bearer some-token";
+        context.Response.Body = new MemoryStream();
+
+        nextCalledRef = new[] { false };
+        return context;
+    }
+
+    private static AuthenticateResult SuccessfulAuth()
+    {
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.NameIdentifier, "user-1") },
+            AuthenticationConstants.JwtBearerScheme));
+        return AuthenticateResult.Success(
+            new AuthenticationTicket(principal, AuthenticationConstants.JwtBearerScheme));
+    }
+
+    // --- DeviceAuthenticationMiddleware ---
+
+    [Fact]
+    public async Task DeviceAuth_InvalidBearer_Returns401_AndDoesNotCallNext()
+    {
+        var context = BuildContext(AuthenticateResult.Fail("invalid signature"), out var nextCalled);
+        var middleware = new DeviceAuthenticationMiddleware(
+            _ => { nextCalled[0] = true; return Task.CompletedTask; },
+            NullLogger<DeviceAuthenticationMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        nextCalled[0].Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeviceAuth_ValidBearer_CallsNext_AndSetsUser()
+    {
+        var context = BuildContext(SuccessfulAuth(), out var nextCalled);
+        var middleware = new DeviceAuthenticationMiddleware(
+            _ => { nextCalled[0] = true; return Task.CompletedTask; },
+            NullLogger<DeviceAuthenticationMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled[0].Should().BeTrue();
+        context.User.Identity!.IsAuthenticated.Should().BeTrue();
+    }
+
+    // --- ApiKeyAuthenticationMiddleware ---
+
+    [Fact]
+    public async Task ApiKeyAuth_InvalidBearer_Returns401_AndDoesNotCallNext()
+    {
+        var context = BuildContext(AuthenticateResult.Fail("expired"), out var nextCalled);
+        var middleware = new ApiKeyAuthenticationMiddleware(
+            _ => { nextCalled[0] = true; return Task.CompletedTask; },
+            Mock.Of<IApiKeyValidator>(),
+            NullLogger<ApiKeyAuthenticationMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        nextCalled[0].Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ApiKeyAuth_ValidBearer_CallsNext_AndSetsUser()
+    {
+        var context = BuildContext(SuccessfulAuth(), out var nextCalled);
+        var middleware = new ApiKeyAuthenticationMiddleware(
+            _ => { nextCalled[0] = true; return Task.CompletedTask; },
+            Mock.Of<IApiKeyValidator>(),
+            NullLogger<ApiKeyAuthenticationMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled[0].Should().BeTrue();
+        context.User.Identity!.IsAuthenticated.Should().BeTrue();
+    }
+}

--- a/tests/SignalBeam.Shared.Infrastructure.Tests/SignalBeam.Shared.Infrastructure.Tests.csproj
+++ b/tests/SignalBeam.Shared.Infrastructure.Tests/SignalBeam.Shared.Infrastructure.Tests.csproj
@@ -16,6 +16,11 @@
     <PackageReference Include="Moq" />
   </ItemGroup>
 
+  <!-- Needed to exercise middleware against HttpContext / IAuthenticationService -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="../../src/Shared/SignalBeam.Shared.Infrastructure/SignalBeam.Shared.Infrastructure.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Problem (High severity — live, public)

`DeviceAuthenticationMiddleware` and `ApiKeyAuthenticationMiddleware` passed **any** `Authorization: Bearer …` value straight through the pipeline without validating it. Endpoints that rely on these middlewares for auth (and don't separately `RequireAuthorization`) then ran for unauthenticated callers:

```
GET /api/devices  -H "Authorization: Bearer eyJ…bogus"  -> 200  {"devices":[],...}
GET /api/devices  (no auth)                              -> 401
```

So a guessable/garbage token reached tenant data through the **public** gateway. Affected `DeviceManager` and `BundleOrchestrator` (both use these middlewares). `IdentityManager` already `RequireAuthorization`s its groups, so it was not affected.

## Fix

Both middlewares now authenticate the bearer via the JWT scheme (`context.AuthenticateAsync("Bearer")`) and **reject with 401** when validation fails (bad signature, wrong issuer/audience, expired). Only a valid token sets the principal and continues.

- `/health`, `/metrics`, `/scalar`, `/openapi` skips unchanged → **probes unaffected**.
- mTLS / device-key / tenant-API-key paths unchanged.
- Pairs with #419/#421 which point the JWT authority+audience at Zitadel, so real dashboard tokens validate.

## Tests

`BearerValidationTests` (new) — for both middlewares: invalid bearer → 401 + `next` not called; valid bearer → `next` called + principal set. All 4 pass.

## Verification plan (post-merge)

Merging rebuilds the `devicemanager`/`bundleorchestrator` images (build workflows watch `src/Shared/**`); then redeploy ACA and confirm `GET /api/devices` with a bogus bearer returns **401**.

## Related finding (separate, not fixed here)

`IdentityManager` `GET /api/tenants/retention-policies` is intentionally anonymous (service-to-service for background workers) but reachable via the public gateway with no caller validation — should get service-auth treatment. Out of scope for this bypass fix.

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)