### PR TITLE
fix device registration 500 by deriving tenant from auth context

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,10 +273,11 @@ VITE_ZITADEL_POST_LOGOUT_REDIRECT_URI=http://localhost:5173
 ```
 Edge Agent
     │
-    │ POST /api/devices (tenantId, deviceName, registrationToken)
+    │ POST /api/devices (name, registrationToken[, tenantId])
     ▼
 API Gateway → DeviceManager
     │
+    │ 0. Resolve tenant (auth claim first, else body tenantId)
     │ 1. Validate registration token
     │ 2. Check device quota
     │
@@ -305,6 +306,14 @@ DeviceManager
     ▼
 Response to Edge Agent
 ```
+
+> **Tenant resolution:** `POST /api/devices` is a public registration handshake, so it
+> authenticates *best-effort* — it accepts mTLS or an API key when present but never rejects an
+> anonymous request (a brand-new device has no key yet). The tenant is taken from the
+> authenticated `tenant_id` claim when present, so a `tenantId` in the request body is **optional**
+> and is honoured only on the anonymous path. Supplying a body `tenantId` that differs from the
+> authenticated tenant does not override it. If neither source yields a tenant the endpoint
+> returns `400 INVALID_TENANT_ID` (rather than a 500).
 
 ### User Registration and Workspace Creation
 

--- a/docs/architecture/authentication-architecture.md
+++ b/docs/architecture/authentication-architecture.md
@@ -814,6 +814,17 @@ public class RegisterDeviceHandler
 └─────────────┘
 ```
 
+> **Note — registration handshake and tenant resolution.** The endpoint is `POST /api/devices`,
+> and it is a *public registration handshake*: the device-auth middleware authenticates
+> best-effort (mTLS or API key when present) but never rejects an anonymous request, since a
+> brand-new device has no credentials yet. The tenant is resolved **claim-first** — the
+> authenticated `tenant_id` claim (from an mTLS cert or tenant/device API key) takes precedence,
+> and the `tenantId` in the request body is used only as a fallback on the anonymous path and
+> cannot override an authenticated tenant. The diagram above shows the JWT/operator path
+> conceptually; note that Bearer tokens are **not** validated on the handshake itself, so a
+> dashboard (JWT) caller supplies the tenant in the request body. When no tenant can be resolved,
+> the endpoint returns `400 INVALID_TENANT_ID` instead of a 500.
+
 ## Security Architecture
 
 ### Defense in Depth

--- a/docs/features/device-authentication.md
+++ b/docs/features/device-authentication.md
@@ -130,6 +130,14 @@ signalbeam-agent register \
   --device-name warehouse-01
 ```
 
+> **Tenant resolution:** registration (`POST /api/devices`) is a public handshake, so `--tenant-id`
+> (sent as `tenantId` in the request body) is required only on this **anonymous** path, where the
+> device has no API key yet. When the caller is already authenticated with a tenant API key — for
+> example an operator registering a device from a script or the dashboard — the tenant is derived
+> from the key's `tenant_id` claim and the body `tenantId` is optional (and cannot override the
+> authenticated tenant). If no tenant can be resolved from either source the endpoint returns
+> `400 INVALID_TENANT_ID`.
+
 Device status: **Pending** (awaiting approval)
 
 ### 3. Approve Device (Admin)

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
@@ -189,14 +189,15 @@ public static class DeviceEndpoints
         [FromServices] RegisterDeviceHandler handler,
         CancellationToken cancellationToken)
     {
-        // Derive the tenant from the authenticated API-key context, falling back to a
-        // body-supplied value for the anonymous registration handshake (no API key yet).
+        // Derive the tenant from the authenticated context, falling back to a body-supplied
+        // value only for the anonymous registration handshake (no API key yet).
         if (!TryResolveTenantId(request.TenantId, context, out var tenantId))
         {
             return Results.BadRequest(new
             {
                 error = "INVALID_TENANT_ID",
-                message = "Tenant ID could not be resolved from the request or authentication context."
+                message = "Tenant ID could not be resolved from the request or authentication context.",
+                type = nameof(ErrorType.Validation)
             });
         }
 
@@ -220,19 +221,27 @@ public static class DeviceEndpoints
     }
 
     /// <summary>
-    /// Resolves the tenant id, preferring an explicitly supplied value and falling back to the
-    /// authenticated tenant claim set by the auth middleware. Mirrors the BundleOrchestrator pattern.
+    /// Resolves the tenant id for device registration. The authenticated tenant claim takes
+    /// precedence so an authenticated caller cannot register a device under a different tenant by
+    /// passing an arbitrary <c>TenantId</c> in the body; the body value is only honoured for the
+    /// anonymous registration handshake, where a brand-new device has no API key and thus no claim.
     /// </summary>
     private static bool TryResolveTenantId(Guid? tenantId, HttpContext context, out Guid resolvedTenantId)
     {
+        var tenantIdClaim = context.User.FindFirst(AuthenticationConstants.TenantIdClaimType)?.Value;
+        if (Guid.TryParse(tenantIdClaim, out resolvedTenantId) && resolvedTenantId != Guid.Empty)
+        {
+            return true;
+        }
+
         if (tenantId.HasValue && tenantId.Value != Guid.Empty)
         {
             resolvedTenantId = tenantId.Value;
             return true;
         }
 
-        var tenantIdClaim = context.User.FindFirst(AuthenticationConstants.TenantIdClaimType)?.Value;
-        return Guid.TryParse(tenantIdClaim, out resolvedTenantId);
+        resolvedTenantId = Guid.Empty;
+        return false;
     }
 
     private static async Task<IResult> GetDevices(

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
@@ -14,6 +14,21 @@ namespace SignalBeam.DeviceManager.Host.Endpoints;
 public record ClaimDeviceApiKeyRequest(string RegistrationToken);
 
 /// <summary>
+/// Request body for registering a device.
+/// <para>
+/// <see cref="TenantId"/> is optional: when an authenticated tenant API key is used, the
+/// tenant is derived from the auth context. It only needs to be supplied on the anonymous
+/// registration handshake, where the caller has no API key yet.
+/// </para>
+/// </summary>
+public record RegisterDeviceRequest(
+    string Name,
+    Guid? TenantId = null,
+    string? Metadata = null,
+    Guid? DeviceId = null,
+    string? RegistrationToken = null);
+
+/// <summary>
 /// Device API endpoints.
 /// </summary>
 public static class DeviceEndpoints
@@ -169,10 +184,29 @@ public static class DeviceEndpoints
     }
 
     private static async Task<IResult> RegisterDevice(
-        RegisterDeviceCommand command,
+        RegisterDeviceRequest request,
+        HttpContext context,
         [FromServices] RegisterDeviceHandler handler,
         CancellationToken cancellationToken)
     {
+        // Derive the tenant from the authenticated API-key context, falling back to a
+        // body-supplied value for the anonymous registration handshake (no API key yet).
+        if (!TryResolveTenantId(request.TenantId, context, out var tenantId))
+        {
+            return Results.BadRequest(new
+            {
+                error = "INVALID_TENANT_ID",
+                message = "Tenant ID could not be resolved from the request or authentication context."
+            });
+        }
+
+        var command = new RegisterDeviceCommand(
+            tenantId,
+            request.Name,
+            request.Metadata,
+            request.DeviceId,
+            request.RegistrationToken);
+
         var result = await handler.Handle(command, cancellationToken);
 
         return result.IsSuccess
@@ -183,6 +217,22 @@ public static class DeviceEndpoints
                 message = result.Error.Message,
                 type = result.Error.Type.ToString()
             });
+    }
+
+    /// <summary>
+    /// Resolves the tenant id, preferring an explicitly supplied value and falling back to the
+    /// authenticated tenant claim set by the auth middleware. Mirrors the BundleOrchestrator pattern.
+    /// </summary>
+    private static bool TryResolveTenantId(Guid? tenantId, HttpContext context, out Guid resolvedTenantId)
+    {
+        if (tenantId.HasValue && tenantId.Value != Guid.Empty)
+        {
+            resolvedTenantId = tenantId.Value;
+            return true;
+        }
+
+        var tenantIdClaim = context.User.FindFirst(AuthenticationConstants.TenantIdClaimType)?.Value;
+        return Guid.TryParse(tenantIdClaim, out resolvedTenantId);
     }
 
     private static async Task<IResult> GetDevices(

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
@@ -232,6 +232,11 @@ public class DeviceAuthenticationMiddleware
     /// present it sets the principal (and tenant claim) so downstream handlers can derive the
     /// tenant from the auth context. Unlike the main path it never rejects — absent or invalid
     /// credentials leave the request anonymous so a brand-new device can still register.
+    /// <para>
+    /// JWT Bearer is intentionally not handled here: device/operator registration uses mTLS or
+    /// API keys, and a dashboard (JWT) caller still supplies the tenant in the request body. Adding
+    /// Bearer validation on the anonymous handshake would risk rejecting otherwise-valid requests.
+    /// </para>
     /// </summary>
     private async Task TryAuthenticateOptionalAsync(
         HttpContext context,

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
@@ -43,11 +43,18 @@ public class DeviceAuthenticationMiddleware
             return;
         }
 
-        // Skip device-key auth for the registration handshake. These endpoints run before the
-        // device holds an API key and are each authenticated by other means in their handlers:
+        // Skip mandatory device-key auth for the registration handshake. These endpoints run before
+        // the device holds an API key and are each authenticated by other means in their handlers:
         // register and claim-key verify the registration token; registration-status returns no secrets.
+        //
+        // The handshake must stay reachable WITHOUT credentials, but when a caller DOES present
+        // valid ones (e.g. an operator registering a device with their tenant API key), authenticate
+        // them best-effort so the tenant can be derived from the auth context instead of the request
+        // body. Absent or invalid credentials simply fall through — never rejected here. (#384)
         if (IsRegistrationHandshake(context.Request))
         {
+            await TryAuthenticateOptionalAsync(
+                context, certificateValidator, apiKeyService, apiKeyValidator, tenantApiKeyValidator);
             await _next(context);
             return;
         }
@@ -218,6 +225,67 @@ public class DeviceAuthenticationMiddleware
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Best-effort authentication for the registration handshake: when valid credentials are
+    /// present it sets the principal (and tenant claim) so downstream handlers can derive the
+    /// tenant from the auth context. Unlike the main path it never rejects — absent or invalid
+    /// credentials leave the request anonymous so a brand-new device can still register.
+    /// </summary>
+    private async Task TryAuthenticateOptionalAsync(
+        HttpContext context,
+        IDeviceCertificateValidator? certificateValidator,
+        IDeviceApiKeyService? apiKeyService,
+        IDeviceApiKeyValidator? apiKeyValidator,
+        IApiKeyValidator? tenantApiKeyValidator)
+    {
+        // Certificate (mTLS) first, mirroring the main path's precedence.
+        var clientCert = context.Connection.ClientCertificate;
+        if (clientCert != null && certificateValidator != null)
+        {
+            var certResult = await certificateValidator.ValidateAsync(clientCert, context.RequestAborted);
+            if (certResult.IsSuccess)
+            {
+                SetUserPrincipal(context, certResult.Value, AuthenticationMethod.Certificate);
+                return;
+            }
+        }
+
+        if (!context.Request.Headers.TryGetValue(
+            AuthenticationConstants.ApiKeyHeaderName,
+            out var apiKeyValue))
+        {
+            return;
+        }
+
+        var apiKey = apiKeyValue.ToString();
+
+        // Device-specific API key (sb_device_{prefix}_{secret}).
+        if (apiKeyService != null && apiKeyValidator != null)
+        {
+            var keyPrefix = apiKeyService.ExtractKeyPrefix(apiKey);
+            if (!string.IsNullOrWhiteSpace(keyPrefix))
+            {
+                var apiKeyResult = await apiKeyValidator.ValidateAsync(
+                    apiKey, keyPrefix, context.RequestAborted);
+                if (apiKeyResult.IsSuccess)
+                {
+                    SetUserPrincipal(context, apiKeyResult.Value, AuthenticationMethod.ApiKey);
+                    return;
+                }
+            }
+        }
+
+        // Tenant-level API key ({tenantId}:{key}:{scopes}).
+        if (tenantApiKeyValidator != null)
+        {
+            var tenantKeyResult = await tenantApiKeyValidator.ValidateAsync(apiKey, context.RequestAborted);
+            if (tenantKeyResult.IsSuccess)
+            {
+                SetTenantPrincipal(context, tenantKeyResult.Value);
+            }
+        }
     }
 
     private void SetUserPrincipal(

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/DeviceEndpointsTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/DeviceEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Queries;
 using SignalBeam.DeviceManager.Host.Endpoints;
@@ -85,16 +86,33 @@ public class DeviceEndpointsTests : IClassFixture<DeviceManagerWebApplicationFac
         // yet, so the device-auth middleware must not reject it. Authorization is enforced
         // in-handler via the registration token, not by requiring a pre-shared API key.
         var unauthenticatedClient = _factory.CreateClient();
-        var request = new RegisterDeviceCommand(
+        var request = new RegisterDeviceRequest(
+            Name: "Test Device",
             TenantId: _factory.DefaultTenantId,
-            DeviceId: Guid.NewGuid(),
-            Name: "Test Device");
+            DeviceId: Guid.NewGuid());
 
         // Act
         var response = await unauthenticatedClient.PostAsJsonAsync("/api/devices", request);
 
         // Assert — reachable (not blocked by device-auth middleware)
         response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task RegisterDevice_WithNoTenantInBodyOrAuthContext_ReturnsBadRequest()
+    {
+        // Regression for #384: when neither the body nor the auth context supplies a tenant, the
+        // endpoint must fail fast with 400 INVALID_TENANT_ID rather than 500 on new TenantId(Empty).
+        var unauthenticatedClient = _factory.CreateClient();
+        var request = new RegisterDeviceRequest(Name: "No Tenant Device");
+
+        // Act
+        var response = await unauthenticatedClient.PostAsJsonAsync("/api/devices", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetString().Should().Be("INVALID_TENANT_ID");
     }
 
     [Fact]

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/DeviceEndpointsTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/DeviceEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Queries;
+using SignalBeam.DeviceManager.Host.Endpoints;
 using SignalBeam.DeviceManager.Tests.Integration.Infrastructure;
 
 namespace SignalBeam.DeviceManager.Tests.Integration;
@@ -43,6 +44,38 @@ public class DeviceEndpointsTests : IClassFixture<DeviceManagerWebApplicationFac
         result.Should().NotBeNull();
         result!.DeviceId.Should().Be(deviceId);
         result.Name.Should().Be("Test Device");
+    }
+
+    [Fact]
+    public async Task RegisterDevice_WithoutBodyTenantId_DerivesTenantFromAuthContext_AndRoundTrips()
+    {
+        // Regression for #384: POST /api/devices with a valid API key but no tenantId in the
+        // body must derive the tenant from the authenticated context (not 500 on Guid.Empty).
+        var deviceId = Guid.NewGuid();
+        var request = new RegisterDeviceRequest(
+            Name: "Tenant From Auth Device",
+            Metadata: "{\"location\":\"lab\"}",
+            DeviceId: deviceId);
+
+        // Act - create deriving tenant from the API key
+        var createResponse = await _client.PostAsJsonAsync("/api/devices", request);
+
+        // Assert - persisted and created (no 500)
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<RegisterDeviceResponse>();
+        created.Should().NotBeNull();
+        created!.DeviceId.Should().Be(deviceId);
+
+        // Act - read it back
+        var getResponse = await _client.GetAsync($"/api/devices/{deviceId}");
+
+        // Assert - round-trips, tenant resolved from the API key's tenant claim
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var device = await getResponse.Content.ReadFromJsonAsync<GetDeviceByIdResponse>();
+        device.Should().NotBeNull();
+        device!.Id.Should().Be(deviceId);
+        device.TenantId.Should().Be(_factory.DefaultTenantId);
+        device.Name.Should().Be("Tenant From Auth Device");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`POST /api/devices` with a valid tenant API key but no `tenantId` in the body returned **HTTP 500** `System.ArgumentException: TenantId cannot be empty`. Found during North Europe ACA end-to-end verification.

Two root causes, both fixed:

1. **Middleware short-circuit** — `DeviceAuthenticationMiddleware.IsRegistrationHandshake()` treats `POST /api/devices` as a public handshake (#279) and returned `_next` *before validating any credentials*, so even a valid API key never set the `tenant_id` claim. It now authenticates **best-effort** on the handshake (mTLS → device key → tenant key, same precedence as the main path): it sets the principal/tenant claim when valid credentials are present, but **never rejects** — a brand-new device with no key can still register.
2. **Endpoint binding** — the endpoint bound `RegisterDeviceCommand` straight from the body, so an absent `tenantId` defaulted to `Guid.Empty` and threw in the `TenantId` value object. A new `RegisterDeviceRequest` DTO (optional `TenantId`) + a `TryResolveTenantId` helper now resolve the tenant from the auth context, returning **400 `INVALID_TENANT_ID`** instead of 500 when no tenant is available.

## Security note

`TryResolveTenantId` uses **claim-first precedence**: the authenticated tenant claim always wins, so an authenticated caller cannot register a device under another tenant by passing an arbitrary `TenantId` in the body. The body value is honoured only for the anonymous handshake (no claim present). The registration-token tenant-ownership check (`token.TenantId == tenantId`) is unchanged as a backstop.

## Changes

- `DeviceAuthenticationMiddleware.cs` — `TryAuthenticateOptionalAsync` best-effort handshake auth (JWT Bearer intentionally excluded; documented inline).
- `DeviceEndpoints.cs` — `RegisterDeviceRequest` DTO, `TryResolveTenantId` (claim-first), `type` field added to the error response.
- `DeviceEndpointsTests.cs` — round-trip test deriving tenant from the API key; 400-guard test for no-tenant-anywhere; handshake test moved to the new DTO.

## Test plan

- ✅ Release build clean (0 warnings, 0 errors)
- ✅ `dotnet format --verify-no-changes` clean
- ✅ DeviceManager unit tests: 29/29
- ✅ `DeviceEndpointsTests` + `DeviceRegistrationIntegrationTests`: **15/15** (incl. the two new tests)
- ✅ No pending EF migrations for DeviceManager (schema-neutral change)
- ℹ️ The wider DeviceManager integration suite has ~28 failures (Tag/Group/Bulk/Dynamic/Heartbeat/rate-limit/OpenAPI) that are **pre-existing on `main`** — verified by running the same suite against clean `origin/main`, which fails identically. They stem from the .NET 10 upgrade and are unrelated to this change.

## Reviewer feedback addressed

Parallel reviewer/verifier/doc-checker ran during completion. Verifier: PASS (both acceptance criteria met). Reviewer warnings addressed in the second commit: cross-tenant body precedence (claim-first), missing `type` in error response, and the missing 400-path test. Doc-checker flagged 3 stale docs (`docs/architecture.md`, `docs/features/device-authentication.md`, `docs/architecture/authentication-architecture.md`) describing `tenantId` as required on `POST /api/devices` — advisory, recommend a follow-up `/docs api device-manager`.

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)