### PR TITLE
fix DeviceManager integration suite (green) and underlying group bugs

### DIFF
--- a/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/AddDeviceToGroup.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Application/Commands/AddDeviceToGroup.cs
@@ -120,6 +120,11 @@ public class AddDeviceToGroupHandler
         await _membershipRepository.AddAsync(membership, cancellationToken);
         await _membershipRepository.SaveChangesAsync(cancellationToken);
 
+        // Keep Device.DeviceGroupId in sync with the membership table so the group-by-device read
+        // path (GetDevicesByGroup) reflects static memberships, not just the membership queries.
+        device.AssignToGroup(deviceGroupId);
+        await _deviceRepository.SaveChangesAsync(cancellationToken);
+
         return Result<AddDeviceToGroupResponse>.Success(new AddDeviceToGroupResponse(
             MembershipId: membership.Id.Value,
             DeviceGroupId: membership.GroupId.Value,

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/GroupEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/GroupEndpoints.cs
@@ -1,5 +1,6 @@
 using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Queries;
+using SignalBeam.Shared.Infrastructure.Authentication;
 using Microsoft.AspNetCore.Mvc;
 
 namespace SignalBeam.DeviceManager.Host.Endpoints;
@@ -61,10 +62,24 @@ public static class GroupEndpoints
     }
 
     private static async Task<IResult> GetDeviceGroups(
-        [AsParameters] GetDeviceGroupsQuery query,
+        HttpContext context,
         [FromServices] GetDeviceGroupsHandler handler,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        [FromQuery] Guid? tenantId = null)
     {
+        // Resolve tenant from the explicit query value or the authenticated context. Binding a
+        // required non-nullable Guid from the query string would 400 before the handler runs.
+        if (!TryResolveTenantId(tenantId, context, out var resolvedTenantId))
+        {
+            return Results.BadRequest(new
+            {
+                error = "INVALID_TENANT_ID",
+                message = "Tenant ID could not be resolved from the request or authentication context.",
+                type = "Validation"
+            });
+        }
+
+        var query = new GetDeviceGroupsQuery(resolvedTenantId);
         var result = await handler.Handle(query, cancellationToken);
 
         return result.IsSuccess
@@ -97,24 +112,56 @@ public static class GroupEndpoints
     private static async Task<IResult> AddDeviceToGroup(
         Guid groupId,
         AddDeviceToGroupRequest request,
-        [FromServices] AssignDeviceToGroupHandler handler,
-        CancellationToken cancellationToken)
+        HttpContext context,
+        [FromServices] AddDeviceToGroupHandler handler,
+        CancellationToken cancellationToken,
+        [FromQuery] Guid? tenantId = null)
     {
-        // Use the existing AssignDeviceToGroup command with the groupId from route
-        var command = new AssignDeviceToGroupCommand(
-            DeviceId: request.DeviceId,
-            DeviceGroupId: groupId);
+        if (!TryResolveTenantId(tenantId, context, out var resolvedTenantId))
+        {
+            return Results.BadRequest(new
+            {
+                error = "INVALID_TENANT_ID",
+                message = "Tenant ID could not be resolved from the request or authentication context.",
+                type = "Validation"
+            });
+        }
 
+        // Add the device to the static group's membership table (the source of truth that the
+        // bulk-tag and membership reads expect). Assigning Device.DeviceGroupId alone is not enough.
+        var command = new AddDeviceToGroupCommand(resolvedTenantId, groupId, request.DeviceId);
         var result = await handler.Handle(command, cancellationToken);
 
         return result.IsSuccess
             ? Results.Ok(result.Value)
-            : Results.BadRequest(new
+            : result.Error!.Code switch
             {
-                error = result.Error!.Code,
-                message = result.Error.Message,
-                type = result.Error.Type.ToString()
-            });
+                "DEVICE_GROUP_ACCESS_DENIED" or "DEVICE_ACCESS_DENIED" => Results.Forbid(),
+                "MEMBERSHIP_ALREADY_EXISTS" => Results.Conflict(result.Error),
+                // DEVICE_GROUP_NOT_FOUND / DEVICE_NOT_FOUND / INVALID_GROUP_TYPE -> 400
+                _ => Results.BadRequest(new
+                {
+                    error = result.Error.Code,
+                    message = result.Error.Message,
+                    type = result.Error.Type.ToString()
+                })
+            };
+    }
+
+    /// <summary>
+    /// Resolves the tenant id from an explicit query value, falling back to the authenticated
+    /// tenant claim set by the auth middleware.
+    /// </summary>
+    private static bool TryResolveTenantId(Guid? tenantId, HttpContext context, out Guid resolvedTenantId)
+    {
+        if (tenantId is { } value && value != Guid.Empty)
+        {
+            resolvedTenantId = value;
+            return true;
+        }
+
+        var tenantIdClaim = context.User.FindFirst(AuthenticationConstants.TenantIdClaimType)?.Value;
+        return Guid.TryParse(tenantIdClaim, out resolvedTenantId) && resolvedTenantId != Guid.Empty;
     }
 
     private static async Task<IResult> UpdateDeviceGroup(

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
@@ -82,7 +82,11 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddAuthorization();
 
-// Add Rate Limiting
+// Add Rate Limiting. Limits are configurable (RateLimiting:*) so they can be tuned per
+// environment and made deterministic in tests; the defaults preserve the original behaviour.
+var rateLimitPermit = builder.Configuration.GetValue<int?>("RateLimiting:PermitLimit") ?? 100;
+var rateLimitWindowSeconds = builder.Configuration.GetValue<int?>("RateLimiting:WindowSeconds") ?? 60;
+var rateLimitQueueLimit = builder.Configuration.GetValue<int?>("RateLimiting:QueueLimit") ?? 10;
 builder.Services.AddRateLimiter(options =>
 {
     options.GlobalLimiter = System.Threading.RateLimiting.PartitionedRateLimiter.Create<HttpContext, string>(context =>
@@ -94,10 +98,10 @@ builder.Services.AddRateLimiter(options =>
             partitionKey: tenantId,
             factory: _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
             {
-                PermitLimit = 100,
-                Window = TimeSpan.FromMinutes(1),
+                PermitLimit = rateLimitPermit,
+                Window = TimeSpan.FromSeconds(rateLimitWindowSeconds),
                 QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst,
-                QueueLimit = 10
+                QueueLimit = rateLimitQueueLimit
             });
     });
 
@@ -254,8 +258,9 @@ if (!app.Environment.IsEnvironment("Testing"))
     }
 }
 
-// Configure the HTTP request pipeline
-if (app.Environment.IsDevelopment())
+// Configure the HTTP request pipeline. API docs are exposed in Development and in the integration
+// Testing environment (so the docs endpoints can be verified), but never in Production.
+if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Testing"))
 {
     app.MapOpenApi();
     app.MapScalarApiReference(options =>

--- a/src/Shared/SignalBeam.Domain/Entities/Device.cs
+++ b/src/Shared/SignalBeam.Domain/Entities/Device.cs
@@ -184,12 +184,20 @@ public class Device : AggregateRoot<DeviceId>
         else if (status == Enums.BundleDeploymentStatus.Completed)
         {
             Status = DeviceStatus.Online;
-            RaiseDomainEvent(new BundleUpdateCompletedEvent(Id, AssignedBundleId!.Value, timestamp));
+            // Only raise the bundle event when a bundle is actually assigned — a device can report
+            // a terminal deployment status with no assigned bundle (e.g. initial state reporting).
+            if (AssignedBundleId is not null)
+            {
+                RaiseDomainEvent(new BundleUpdateCompletedEvent(Id, AssignedBundleId.Value, timestamp));
+            }
         }
         else if (status == Enums.BundleDeploymentStatus.Failed)
         {
             Status = DeviceStatus.Error;
-            RaiseDomainEvent(new BundleUpdateFailedEvent(Id, AssignedBundleId!.Value, timestamp));
+            if (AssignedBundleId is not null)
+            {
+                RaiseDomainEvent(new BundleUpdateFailedEvent(Id, AssignedBundleId.Value, timestamp));
+            }
         }
     }
 

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/AuthenticationAndRateLimitingTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/AuthenticationAndRateLimitingTests.cs
@@ -22,22 +22,19 @@ public class AuthenticationAndRateLimitingTests : IClassFixture<DeviceManagerWeb
     [Fact]
     public async Task Request_WithoutApiKey_ReturnsUnauthorized()
     {
-        // Arrange
+        // Arrange — device registration (POST /api/devices) is now a public handshake (#279), so
+        // assert the no-credentials rejection against a still-protected endpoint (device lookup).
         var client = _factory.CreateClient();
-        var request = new RegisterDeviceCommand(
-            TenantId: _factory.DefaultTenantId,
-            DeviceId: Guid.NewGuid(),
-            Name: "Test Device");
 
         // Act
-        var response = await client.PostAsJsonAsync("/api/devices", request);
+        var response = await client.GetAsync($"/api/devices/{Guid.NewGuid()}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
         var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
         error.Should().NotBeNull();
-        error!.Error.Should().Be("missing_api_key");
+        error!.Error.Should().Be("MISSING_CREDENTIALS");
     }
 
     [Fact]
@@ -131,33 +128,24 @@ public class AuthenticationAndRateLimitingTests : IClassFixture<DeviceManagerWeb
     [Fact]
     public async Task RateLimiting_ExceedingLimit_ReturnsTooManyRequests()
     {
-        // Arrange
+        // Arrange — fire concurrently and exceed the 100-permit window. Requests must be concurrent:
+        // sequential awaited calls would each acquire a fresh permit as the window rolls and never
+        // be rejected. The test environment sets QueueLimit=0 so excess requests reject immediately.
         var client = _factory.CreateAuthenticatedClient();
-        var successfulRequests = 0;
-        var rateLimitedRequests = 0;
+        const int totalRequests = 150;
 
-        // Act - Send many requests rapidly (more than the limit)
-        for (int i = 0; i < 105; i++) // Limit is 100 per minute
-        {
-            var request = new RegisterDeviceCommand(
+        // Act
+        var responses = await Task.WhenAll(Enumerable.Range(0, totalRequests).Select(i =>
+            client.PostAsJsonAsync("/api/devices", new RegisterDeviceCommand(
                 TenantId: _factory.DefaultTenantId,
                 DeviceId: Guid.NewGuid(),
-                Name: $"Device {i}");
+                Name: $"Device {i}"))));
 
-            var response = await client.PostAsJsonAsync("/api/devices", request);
-
-            if (response.StatusCode == HttpStatusCode.Created)
-            {
-                successfulRequests++;
-            }
-            else if (response.StatusCode == HttpStatusCode.TooManyRequests)
-            {
-                rateLimitedRequests++;
-            }
-        }
+        var successfulRequests = responses.Count(r => r.StatusCode == HttpStatusCode.Created);
+        var rateLimitedRequests = responses.Count(r => r.StatusCode == HttpStatusCode.TooManyRequests);
 
         // Assert - Should have some rate-limited requests
-        rateLimitedRequests.Should().BeGreaterThan(0, "Rate limiting should kick in after 100 requests");
+        rateLimitedRequests.Should().BeGreaterThan(0, "Rate limiting should reject requests beyond the permit limit");
         successfulRequests.Should().BeLessThanOrEqualTo(100, "Should not exceed the rate limit");
     }
 

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/BulkOperationsIntegrationTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/BulkOperationsIntegrationTests.cs
@@ -284,7 +284,7 @@ public class BulkOperationsIntegrationTests : IClassFixture<DeviceManagerWebAppl
             Name: name,
             Metadata: null);
 
-        var response = await _client.PostAsJsonAsync("/api/devices/register", registerCommand);
+        var response = await _client.PostAsJsonAsync("/api/devices", registerCommand);
         response.EnsureSuccessStatusCode();
 
         var result = await response.Content.ReadFromJsonAsync<RegisterDeviceResponse>();

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/DynamicGroupsIntegrationTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/DynamicGroupsIntegrationTests.cs
@@ -104,12 +104,17 @@ public class DynamicGroupsIntegrationTests : IClassFixture<DeviceManagerWebAppli
     [Fact]
     public async Task DynamicGroup_AutomaticallyIncludesMatchingDevices_WhenDeviceTagsMatch()
     {
+        // Namespace tag values and the group name so the shared class database can't leak matches
+        // from sibling tests (group names are unique per tenant; the dynamic query matches by tag).
+        // Leading letter required: the tag-query tokenizer rejects identifiers that start with a digit.
+        var ns = $"n{Guid.NewGuid():N}"[..8];
+
         // Arrange - Create a dynamic group with a tag query
         var groupRequest = new CreateDeviceGroupCommand(
             TenantId: _factory.DefaultTenantId,
-            Name: "Production Devices Group",
+            Name: $"Production Devices Group-{ns}",
             Type: GroupType.Dynamic,
-            TagQuery: "environment=production");
+            TagQuery: $"environment={ns}production");
 
         var groupResponse = await _client.PostAsJsonAsync("/api/groups", groupRequest);
         var group = await groupResponse.Content.ReadFromJsonAsync<CreateDeviceGroupResponse>();
@@ -119,9 +124,9 @@ public class DynamicGroupsIntegrationTests : IClassFixture<DeviceManagerWebAppli
         var prodDevice2Id = await CreateTestDeviceAsync("prod-device-2");
         var devDeviceId = await CreateTestDeviceAsync("dev-device-1");
 
-        await _client.PostAsJsonAsync($"/api/devices/{prodDevice1Id}/tags", new AddDeviceTagCommand(prodDevice1Id, "environment=production"));
-        await _client.PostAsJsonAsync($"/api/devices/{prodDevice2Id}/tags", new AddDeviceTagCommand(prodDevice2Id, "environment=production"));
-        await _client.PostAsJsonAsync($"/api/devices/{devDeviceId}/tags", new AddDeviceTagCommand(devDeviceId, "environment=dev"));
+        await _client.PostAsJsonAsync($"/api/devices/{prodDevice1Id}/tags", new AddDeviceTagCommand(prodDevice1Id, $"environment={ns}production"));
+        await _client.PostAsJsonAsync($"/api/devices/{prodDevice2Id}/tags", new AddDeviceTagCommand(prodDevice2Id, $"environment={ns}production"));
+        await _client.PostAsJsonAsync($"/api/devices/{devDeviceId}/tags", new AddDeviceTagCommand(devDeviceId, $"environment={ns}dev"));
 
         // Act - Trigger dynamic group membership update manually
         using var scope = _factory.Services.CreateScope();
@@ -308,7 +313,7 @@ public class DynamicGroupsIntegrationTests : IClassFixture<DeviceManagerWebAppli
             Name: name,
             Metadata: null);
 
-        var response = await _client.PostAsJsonAsync("/api/devices/register", registerCommand);
+        var response = await _client.PostAsJsonAsync("/api/devices", registerCommand);
         response.EnsureSuccessStatusCode();
 
         var result = await response.Content.ReadFromJsonAsync<RegisterDeviceResponse>();

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/GroupEndpointsTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/GroupEndpointsTests.cs
@@ -251,9 +251,11 @@ public class GroupEndpointsTests : IClassFixture<DeviceManagerWebApplicationFact
     /// </summary>
     private async Task<Guid> CreateTestGroupAsync(string name)
     {
+        // Suffix the name to keep it unique within the class-shared database (group names must be
+        // unique per tenant), so sibling tests creating a same-named group don't collide.
         var request = new CreateDeviceGroupCommand(
             TenantId: _factory.DefaultTenantId,
-            Name: name);
+            Name: $"{name}-{Guid.NewGuid():N}");
 
         var response = await _client.PostAsJsonAsync("/api/groups", request);
         var group = await response.Content.ReadFromJsonAsync<CreateDeviceGroupResponse>();

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/Infrastructure/DeviceManagerWebApplicationFactory.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/Infrastructure/DeviceManagerWebApplicationFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SignalBeam.DeviceManager.Application.Services;
@@ -32,6 +33,18 @@ public class DeviceManagerWebApplicationFactory : WebApplicationFactory<Program>
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        // Deterministic rate limiting for tests: no queue, so requests beyond the permit limit are
+        // rejected immediately instead of waiting a full window (which would make the test hang).
+        builder.ConfigureAppConfiguration(config =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["RateLimiting:PermitLimit"] = "100",
+                ["RateLimiting:WindowSeconds"] = "60",
+                ["RateLimiting:QueueLimit"] = "0"
+            });
+        });
+
         builder.ConfigureTestServices(services =>
         {
             // Remove the existing DbContext registration

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/TagOperationsIntegrationTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/TagOperationsIntegrationTests.cs
@@ -163,12 +163,15 @@ public class TagOperationsIntegrationTests : IClassFixture<DeviceManagerWebAppli
         var device2Id = await CreateTestDeviceAsync("search-test-warehouse-2");
         var device3Id = await CreateTestDeviceAsync("search-test-office");
 
-        await _client.PostAsJsonAsync($"/api/devices/{device1Id}/tags", new AddDeviceTagCommand(device1Id, "location=warehouse-seattle"));
-        await _client.PostAsJsonAsync($"/api/devices/{device2Id}/tags", new AddDeviceTagCommand(device2Id, "location=warehouse-portland"));
-        await _client.PostAsJsonAsync($"/api/devices/{device3Id}/tags", new AddDeviceTagCommand(device3Id, "location=office-nyc"));
+        // Namespace tag values so the shared class database can't leak matches from sibling tests.
+        // Leading letter required: the tag-query tokenizer rejects identifiers that start with a digit.
+        var ns = $"n{Guid.NewGuid():N}"[..8];
+        await _client.PostAsJsonAsync($"/api/devices/{device1Id}/tags", new AddDeviceTagCommand(device1Id, $"location={ns}warehouse-seattle"));
+        await _client.PostAsJsonAsync($"/api/devices/{device2Id}/tags", new AddDeviceTagCommand(device2Id, $"location={ns}warehouse-portland"));
+        await _client.PostAsJsonAsync($"/api/devices/{device3Id}/tags", new AddDeviceTagCommand(device3Id, $"location={ns}office-nyc"));
 
         // Act - Search with wildcard
-        var query = "location=warehouse-*";
+        var query = $"location={ns}warehouse-*";
         var response = await _client.GetAsync($"/api/devices/search?tenantId={_factory.DefaultTenantId}&query={Uri.EscapeDataString(query)}");
 
         // Assert
@@ -218,12 +221,15 @@ public class TagOperationsIntegrationTests : IClassFixture<DeviceManagerWebAppli
         var device2Id = await CreateTestDeviceAsync("search-test-or-2");
         var device3Id = await CreateTestDeviceAsync("search-test-or-3");
 
-        await _client.PostAsJsonAsync($"/api/devices/{device1Id}/tags", new AddDeviceTagCommand(device1Id, "hardware=rpi4"));
-        await _client.PostAsJsonAsync($"/api/devices/{device2Id}/tags", new AddDeviceTagCommand(device2Id, "hardware=rpi5"));
-        await _client.PostAsJsonAsync($"/api/devices/{device3Id}/tags", new AddDeviceTagCommand(device3Id, "hardware=x86"));
+        // Namespace tag values so the shared class database can't leak matches from sibling tests.
+        // Leading letter required: the tag-query tokenizer rejects identifiers that start with a digit.
+        var ns = $"n{Guid.NewGuid():N}"[..8];
+        await _client.PostAsJsonAsync($"/api/devices/{device1Id}/tags", new AddDeviceTagCommand(device1Id, $"hardware={ns}rpi4"));
+        await _client.PostAsJsonAsync($"/api/devices/{device2Id}/tags", new AddDeviceTagCommand(device2Id, $"hardware={ns}rpi5"));
+        await _client.PostAsJsonAsync($"/api/devices/{device3Id}/tags", new AddDeviceTagCommand(device3Id, $"hardware={ns}x86"));
 
         // Act
-        var query = "hardware=rpi4 OR hardware=rpi5";
+        var query = $"hardware={ns}rpi4 OR hardware={ns}rpi5";
         var response = await _client.GetAsync($"/api/devices/search?tenantId={_factory.DefaultTenantId}&query={Uri.EscapeDataString(query)}");
 
         // Assert
@@ -267,24 +273,28 @@ public class TagOperationsIntegrationTests : IClassFixture<DeviceManagerWebAppli
         var device3Id = await CreateTestDeviceAsync("complex-search-3");
         var device4Id = await CreateTestDeviceAsync("complex-search-4");
 
+        // Namespace tag values so the shared class database can't leak matches from sibling tests.
+        // Leading letter required: the tag-query tokenizer rejects identifiers that start with a digit.
+        var ns = $"n{Guid.NewGuid():N}"[..8];
+
         // Production warehouse device
-        await _client.PostAsJsonAsync($"/api/devices/{device1Id}/tags", new AddDeviceTagCommand(device1Id, "environment=production"));
-        await _client.PostAsJsonAsync($"/api/devices/{device1Id}/tags", new AddDeviceTagCommand(device1Id, "location=warehouse-seattle"));
+        await _client.PostAsJsonAsync($"/api/devices/{device1Id}/tags", new AddDeviceTagCommand(device1Id, $"environment={ns}production"));
+        await _client.PostAsJsonAsync($"/api/devices/{device1Id}/tags", new AddDeviceTagCommand(device1Id, $"location={ns}warehouse-seattle"));
 
         // Staging warehouse device
-        await _client.PostAsJsonAsync($"/api/devices/{device2Id}/tags", new AddDeviceTagCommand(device2Id, "environment=staging"));
-        await _client.PostAsJsonAsync($"/api/devices/{device2Id}/tags", new AddDeviceTagCommand(device2Id, "location=warehouse-portland"));
+        await _client.PostAsJsonAsync($"/api/devices/{device2Id}/tags", new AddDeviceTagCommand(device2Id, $"environment={ns}staging"));
+        await _client.PostAsJsonAsync($"/api/devices/{device2Id}/tags", new AddDeviceTagCommand(device2Id, $"location={ns}warehouse-portland"));
 
         // Production office device (should not match)
-        await _client.PostAsJsonAsync($"/api/devices/{device3Id}/tags", new AddDeviceTagCommand(device3Id, "environment=production"));
-        await _client.PostAsJsonAsync($"/api/devices/{device3Id}/tags", new AddDeviceTagCommand(device3Id, "location=office-nyc"));
+        await _client.PostAsJsonAsync($"/api/devices/{device3Id}/tags", new AddDeviceTagCommand(device3Id, $"environment={ns}production"));
+        await _client.PostAsJsonAsync($"/api/devices/{device3Id}/tags", new AddDeviceTagCommand(device3Id, $"location={ns}office-nyc"));
 
         // Dev warehouse device (should not match)
-        await _client.PostAsJsonAsync($"/api/devices/{device4Id}/tags", new AddDeviceTagCommand(device4Id, "environment=dev"));
-        await _client.PostAsJsonAsync($"/api/devices/{device4Id}/tags", new AddDeviceTagCommand(device4Id, "location=warehouse-austin"));
+        await _client.PostAsJsonAsync($"/api/devices/{device4Id}/tags", new AddDeviceTagCommand(device4Id, $"environment={ns}dev"));
+        await _client.PostAsJsonAsync($"/api/devices/{device4Id}/tags", new AddDeviceTagCommand(device4Id, $"location={ns}warehouse-austin"));
 
         // Act
-        var query = "(environment=production OR environment=staging) AND location=warehouse-*";
+        var query = $"(environment={ns}production OR environment={ns}staging) AND location={ns}warehouse-*";
         var response = await _client.GetAsync($"/api/devices/search?tenantId={_factory.DefaultTenantId}&query={Uri.EscapeDataString(query)}");
 
         // Assert
@@ -322,7 +332,7 @@ public class TagOperationsIntegrationTests : IClassFixture<DeviceManagerWebAppli
             Name: name,
             Metadata: null);
 
-        var response = await _client.PostAsJsonAsync("/api/devices/register", registerCommand);
+        var response = await _client.PostAsJsonAsync("/api/devices", registerCommand);
         response.EnsureSuccessStatusCode();
 
         var result = await response.Content.ReadFromJsonAsync<RegisterDeviceResponse>();


### PR DESCRIPTION
## Summary

The DeviceManager integration suite was red on `main` (28 of 76 failing) — the "integration tests" gate had been meaningless since the .NET 10 upgrade. This restores it to **76/76, deterministically** (verified across multiple full runs), and fixes three genuine production bugs uncovered along the way.

## Production bugs fixed (not just tests)

1. **Group membership was broken.** `POST /api/groups/{groupId}/devices` was wired to `AssignDeviceToGroupHandler`, which only set `Device.DeviceGroupId` and **never created a `DeviceGroupMembership` row**. Bulk-tag and membership reads (which use the membership table) therefore saw an empty group. Re-wired to `AddDeviceToGroupHandler` (validates the group exists + writes membership), and kept `Device.DeviceGroupId` in sync so the group-by-device read path (`GetDevicesByGroup`) stays consistent.
2. **`GetDeviceGroups` 400'd on a missing tenant.** It bound a required non-nullable `Guid TenantId` via `[AsParameters]`, which .NET 10 rejects at binding before the handler. Now resolves the tenant from the query value or the authenticated claim.
3. **NRE in the domain.** `Device.UpdateBundleDeploymentStatus` dereferenced `AssignedBundleId!.Value` when a device reported `Completed`/`Failed` with no assigned bundle → 500. Now only raises the bundle event when a bundle is actually assigned.

## Production config (for testability/ops)

- Rate limiter limits are now read from configuration (`RateLimiting:*`) with the original values as defaults — tunable per environment and deterministic in tests.
- OpenAPI/Scalar are served in the `Testing` environment as well as `Development` (never Production), so the docs-reachability tests can run.

## Test fixes

- **Stale route:** corrected `POST /api/devices/register` → `/api/devices` in the Tag/Bulk/DynamicGroups device-create helpers (the real handshake is `POST /api/devices`; `/register` 404'd, failing every test using the helper — this alone was 10 failures).
- **Test isolation:** the factory resets the DB once per class, so tag-search/dynamic-group tests collided on shared tag values and group names. Namespaced each with a per-test token. The token is **letter-led** because the tag-query tokenizer rejects identifiers starting with a digit (this was an intermittent 400).
- **Rate limiting:** the test host sets `QueueLimit=0` and the test now fires requests **concurrently** past the permit limit. The old sequential loop of 105 never exceeded permit(100)+queue(10), so nothing was ever rejected.
- **Stale auth test:** `Request_WithoutApiKey` now asserts against a still-protected endpoint (registration became a public handshake in #279).

## Test plan

- ✅ DeviceManager integration: **76/76**, deterministic across repeated full runs
- ✅ All solution unit tests pass (Domain 117, DeviceManager 29, EdgeAgent 54, BundleOrchestrator 48, IdentityManager 53, Shared 43)
- ✅ Release build + `dotnet format --verify-no-changes` clean
- ✅ The shared `Device.cs` change is covered by Domain unit tests (still green)

## Known follow-up (out of scope)

`TelemetryProcessor.Tests.Integration` (5) and `EdgeAgent.Tests.Integration` (1) are also red on `main` from the same .NET 10 rot — different services, different root causes (and these don't exercise any code changed here). Worth a separate issue/PR. Also note: these integration test projects aren't tagged `[Trait("Category","Integration")]`, so they run under a `Category!=Integration` filter — tagging them would let the unit-test gate skip Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)