### PR TITLE
harden the anonymous device-registration handshake (#430)

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -38,6 +38,7 @@ Every new endpoint MUST have authentication. The project uses a layered auth mid
 - Every new endpoint requires auth unless it is a health check, metrics, or explicitly public registration endpoint
 - If an endpoint must be public, annotate with `.AllowAnonymous()` and add a code comment explaining why
 - Service-to-service endpoints (e.g., quota checks) that use `.AllowAnonymous()` must validate the caller via other means (internal network, service token)
+- The anonymous device-registration handshake (`POST /api/devices`) is rate-limited per client IP (`RateLimitPolicies.DeviceRegistration`, configurable via `RateLimiting:Registration:*`) so it can't be used to flood Pending devices; operators that don't use tokenless onboarding can require a token via `Registration:RequireRegistrationToken`
 - Never add a new service without authentication middleware — TelemetryProcessor and ApiGateway are known gaps to be fixed
 - Path exclusions in middleware (health, metrics, scalar, openapi) must use exact prefix matching, not contains
 

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/DeviceRegistrationOptions.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/DeviceRegistrationOptions.cs
@@ -1,0 +1,19 @@
+namespace SignalBeam.DeviceManager.Host;
+
+/// <summary>
+/// Options for the device-registration handshake. Bound from the <c>Registration</c> configuration
+/// section.
+/// </summary>
+public sealed class DeviceRegistrationOptions
+{
+    public const string SectionName = "Registration";
+
+    /// <summary>
+    /// When <c>true</c>, the anonymous registration handshake (<c>POST /api/devices</c>) requires a
+    /// registration token — tokenless <c>Pending</c> registration is rejected. Default <c>false</c>
+    /// preserves the open handshake (a brand-new device can register and await approval). Operators
+    /// who don't use tokenless onboarding can enable this to close the anonymous-spam surface
+    /// entirely; the EdgeAgent always supplies a token.
+    /// </summary>
+    public bool RequireRegistrationToken { get; set; }
+}

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
@@ -5,6 +5,7 @@ using SignalBeam.Domain.Enums;
 using SignalBeam.Shared.Infrastructure.Authentication;
 using SignalBeam.Shared.Infrastructure.Results;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace SignalBeam.DeviceManager.Host.Endpoints;
 
@@ -44,7 +45,9 @@ public static class DeviceEndpoints
         group.MapPost("/", RegisterDevice)
             .WithName("RegisterDevice")
             .WithSummary("Register a new device")
-            .WithDescription("Registers a new device in the system with the specified tenant and metadata.");
+            .WithDescription("Registers a new device in the system with the specified tenant and metadata.")
+            // Anonymous handshake — rate-limit per client IP so it can't be used to flood Pending devices.
+            .RequireRateLimiting(RateLimitPolicies.DeviceRegistration);
 
         group.MapGet("/{deviceId:guid}/registration-status", GetRegistrationStatus)
             .WithName("GetRegistrationStatus")
@@ -187,8 +190,22 @@ public static class DeviceEndpoints
         RegisterDeviceRequest request,
         HttpContext context,
         [FromServices] RegisterDeviceHandler handler,
+        [FromServices] IOptions<DeviceRegistrationOptions> registrationOptions,
         CancellationToken cancellationToken)
     {
+        // Optionally require a registration token even for the initial handshake, so operators who
+        // don't use tokenless onboarding can close the anonymous-registration surface entirely.
+        if (registrationOptions.Value.RequireRegistrationToken
+            && string.IsNullOrWhiteSpace(request.RegistrationToken))
+        {
+            return Results.BadRequest(new
+            {
+                error = "REGISTRATION_TOKEN_REQUIRED",
+                message = "A registration token is required to register a device.",
+                type = nameof(ErrorType.Validation)
+            });
+        }
+
         // Derive the tenant from the authenticated context, falling back to a body-supplied
         // value only for the anonymous registration handshake (no API key yet).
         if (!TryResolveTenantId(request.TenantId, context, out var tenantId))

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
@@ -1,6 +1,7 @@
 using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Queries;
 using SignalBeam.DeviceManager.Application.Validators;
+using SignalBeam.DeviceManager.Host;
 using SignalBeam.DeviceManager.Host.Endpoints;
 using SignalBeam.DeviceManager.Host.Metrics;
 using SignalBeam.DeviceManager.Host.Middleware;
@@ -13,6 +14,8 @@ using SignalBeam.Shared.Infrastructure.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.OpenApi;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -87,6 +90,15 @@ builder.Services.AddAuthorization();
 var rateLimitPermit = builder.Configuration.GetValue<int?>("RateLimiting:PermitLimit") ?? 100;
 var rateLimitWindowSeconds = builder.Configuration.GetValue<int?>("RateLimiting:WindowSeconds") ?? 60;
 var rateLimitQueueLimit = builder.Configuration.GetValue<int?>("RateLimiting:QueueLimit") ?? 10;
+
+// Device registration (POST /api/devices) is an anonymous handshake, so the global limiter buckets
+// every unauthenticated caller into one shared "anonymous" partition. Add a tighter, per-client-IP
+// limit dedicated to registration so a single source can't flood a tenant with Pending devices.
+// Bound as options and resolved per request so the limit can be overridden (e.g. in tests).
+builder.Services.Configure<RegistrationRateLimitOptions>(
+    builder.Configuration.GetSection(RegistrationRateLimitOptions.SectionName));
+builder.Services.Configure<DeviceRegistrationOptions>(
+    builder.Configuration.GetSection(DeviceRegistrationOptions.SectionName));
 builder.Services.AddRateLimiter(options =>
 {
     options.GlobalLimiter = System.Threading.RateLimiting.PartitionedRateLimiter.Create<HttpContext, string>(context =>
@@ -102,6 +114,22 @@ builder.Services.AddRateLimiter(options =>
                 Window = TimeSpan.FromSeconds(rateLimitWindowSeconds),
                 QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst,
                 QueueLimit = rateLimitQueueLimit
+            });
+    });
+
+    options.AddPolicy(RateLimitPolicies.DeviceRegistration, context =>
+    {
+        var registration = context.RequestServices
+            .GetRequiredService<IOptions<RegistrationRateLimitOptions>>().Value;
+
+        return System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: $"reg:{GetClientIpAddress(context)}",
+            factory: _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+            {
+                PermitLimit = registration.PermitLimit,
+                Window = TimeSpan.FromSeconds(registration.WindowSeconds),
+                QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0
             });
     });
 
@@ -329,6 +357,23 @@ static string? GetAudienceFromZitadelConfig(IConfiguration configuration)
     }
 
     return null;
+}
+
+// Resolves the originating client IP for rate-limit partitioning. Behind the ACA ingress / gateway
+// the socket address is the proxy, so prefer the first hop of X-Forwarded-For.
+static string GetClientIpAddress(HttpContext context)
+{
+    var forwardedFor = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+    if (!string.IsNullOrWhiteSpace(forwardedFor))
+    {
+        var firstHop = forwardedFor.Split(',')[0].Trim();
+        if (!string.IsNullOrEmpty(firstHop))
+        {
+            return firstHop;
+        }
+    }
+
+    return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
 }
 
 // Make Program accessible to WebApplicationFactory in tests

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/RateLimitPolicies.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/RateLimitPolicies.cs
@@ -1,0 +1,29 @@
+namespace SignalBeam.DeviceManager.Host;
+
+/// <summary>
+/// Named rate-limiter policy keys applied to specific endpoints (on top of the global limiter).
+/// </summary>
+public static class RateLimitPolicies
+{
+    /// <summary>
+    /// Per-client-IP limit for the anonymous device-registration handshake (POST /api/devices),
+    /// so a single source cannot flood a tenant with Pending device records.
+    /// </summary>
+    public const string DeviceRegistration = "device-registration";
+}
+
+/// <summary>
+/// Options for the per-client-IP registration rate limit. Bound from the
+/// <c>RateLimiting:Registration</c> configuration section and resolved per request so tests can
+/// override it via DI.
+/// </summary>
+public sealed class RegistrationRateLimitOptions
+{
+    public const string SectionName = "RateLimiting:Registration";
+
+    /// <summary>Max registration requests per window per client IP.</summary>
+    public int PermitLimit { get; set; } = 10;
+
+    /// <summary>Fixed window length in seconds.</summary>
+    public int WindowSeconds { get; set; } = 60;
+}

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/Infrastructure/DeviceManagerWebApplicationFactory.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/Infrastructure/DeviceManagerWebApplicationFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SignalBeam.DeviceManager.Application.Services;
+using SignalBeam.DeviceManager.Host;
 using SignalBeam.DeviceManager.Infrastructure.Persistence;
 using SignalBeam.Shared.Infrastructure.Authentication;
 using Testcontainers.PostgreSql;
@@ -65,6 +66,12 @@ public class DeviceManagerWebApplicationFactory : WebApplicationFactory<Program>
             // registration doesn't make a real HTTP call to a non-running IdentityManager.
             services.RemoveAll<IDeviceQuotaValidator>();
             services.AddSingleton<IDeviceQuotaValidator>(new TestDeviceQuotaValidator());
+
+            // Functional tests register several devices from the same loopback IP within the window;
+            // keep the per-IP registration limit effectively disabled here. The dedicated
+            // registration rate-limit test overrides this with a low value. (Configured via DI
+            // because ConfigureAppConfiguration does not override startup-read config in the WAF.)
+            services.Configure<RegistrationRateLimitOptions>(o => o.PermitLimit = int.MaxValue);
         });
 
         builder.UseEnvironment("Testing");

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/RegistrationRateLimitTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/RegistrationRateLimitTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using SignalBeam.DeviceManager.Host;
+using SignalBeam.DeviceManager.Host.Endpoints;
+using SignalBeam.DeviceManager.Tests.Integration.Infrastructure;
+
+namespace SignalBeam.DeviceManager.Tests.Integration;
+
+/// <summary>
+/// Test factory that tightens the anonymous registration per-IP rate limit so it can be exercised
+/// deterministically. The base factory keeps it high so functional tests aren't rate-limited.
+/// </summary>
+public class RegistrationRateLimitedFactory : DeviceManagerWebApplicationFactory
+{
+    public const int RegistrationPermit = 5;
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        // Runs after the base ConfigureTestServices, so this value wins.
+        builder.ConfigureTestServices(services =>
+            services.Configure<RegistrationRateLimitOptions>(o => o.PermitLimit = RegistrationPermit));
+    }
+}
+
+/// <summary>
+/// Verifies that the anonymous device-registration handshake is rate-limited per client IP so it
+/// cannot be used to flood a tenant with Pending devices (#430).
+/// </summary>
+public class RegistrationRateLimitTests : IClassFixture<RegistrationRateLimitedFactory>
+{
+    private readonly RegistrationRateLimitedFactory _factory;
+    private readonly HttpClient _client;
+
+    public RegistrationRateLimitTests(RegistrationRateLimitedFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient(); // unauthenticated — the public registration handshake
+    }
+
+    [Fact]
+    public async Task RegistrationHandshake_ExceedingPerIpLimit_ReturnsTooManyRequests()
+    {
+        // Fire well past the per-IP permit concurrently; all requests share the test host's loopback
+        // IP, so they land in one registration partition.
+        const int totalRequests = 20;
+
+        var responses = await Task.WhenAll(Enumerable.Range(0, totalRequests).Select(i =>
+            _client.PostAsJsonAsync("/api/devices", new RegisterDeviceRequest(
+                Name: $"rl-device-{i}",
+                TenantId: _factory.DefaultTenantId))));
+
+        var created = responses.Count(r => r.StatusCode == HttpStatusCode.Created);
+        var rateLimited = responses.Count(r => r.StatusCode == HttpStatusCode.TooManyRequests);
+
+        rateLimited.Should().BeGreaterThan(0, "the per-IP registration limit should reject the flood");
+        created.Should().BeLessThanOrEqualTo(RegistrationRateLimitedFactory.RegistrationPermit,
+            "successful registrations should not exceed the per-IP permit");
+    }
+}

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/RegistrationTokenRequiredTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/RegistrationTokenRequiredTests.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using SignalBeam.DeviceManager.Host;
+using SignalBeam.DeviceManager.Host.Endpoints;
+using SignalBeam.DeviceManager.Tests.Integration.Infrastructure;
+
+namespace SignalBeam.DeviceManager.Tests.Integration;
+
+/// <summary>
+/// Test factory with the opt-in "require registration token" policy enabled.
+/// </summary>
+public class TokenRequiredRegistrationFactory : DeviceManagerWebApplicationFactory
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureTestServices(services =>
+            services.Configure<DeviceRegistrationOptions>(o => o.RequireRegistrationToken = true));
+    }
+}
+
+/// <summary>
+/// Verifies the opt-in policy (#430) that requires a registration token even for the initial
+/// handshake, closing the tokenless anonymous-registration surface.
+/// </summary>
+public class RegistrationTokenRequiredTests : IClassFixture<TokenRequiredRegistrationFactory>
+{
+    private readonly TokenRequiredRegistrationFactory _factory;
+    private readonly HttpClient _client;
+
+    public RegistrationTokenRequiredTests(TokenRequiredRegistrationFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Register_WithoutToken_WhenTokenRequired_ReturnsBadRequest()
+    {
+        var request = new RegisterDeviceRequest(
+            Name: "no-token-device",
+            TenantId: _factory.DefaultTenantId);
+
+        var response = await _client.PostAsJsonAsync("/api/devices", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetString().Should().Be("REGISTRATION_TOKEN_REQUIRED");
+    }
+}


### PR DESCRIPTION
## Summary

`POST /api/devices` is an anonymous handshake (a brand-new device has no credential yet), so anyone who knows a `tenantId` can create `Pending` device records. Verified live this is open. This adds two complementary hardening controls.

Addresses #430 (the third acceptance item — pruning stale `Pending` devices — is deferred; see below).

## Changes

**1. Per-client-IP rate limit dedicated to registration**
- New named policy `RateLimitPolicies.DeviceRegistration` applied to `POST /api/devices`. The global limiter buckets every unauthenticated caller into one shared `"anonymous"` partition; this adds a tighter per-IP cap so a single source can't flood a tenant.
- **Forwarded-header aware** (`X-Forwarded-For` first hop) since behind the ACA ingress the socket IP is the proxy.
- Configurable via `RateLimiting:Registration:*` (default 10/min/IP), bound as `IOptions` and resolved per request.

**2. Opt-in `Registration:RequireRegistrationToken` (default off)**
- When enabled, tokenless registration is rejected with `400 REGISTRATION_TOKEN_REQUIRED`, letting operators who don't use tokenless onboarding close the anonymous surface entirely. The EdgeAgent CLI always sends a token, so enabling it doesn't affect real onboarding.
- Default off preserves the current open handshake — flipping the default is a product decision, not made here.

## Implementation note

The limits are bound via `IOptions` and the tests override them through `services.Configure` in `ConfigureTestServices` — because the WAF's `ConfigureAppConfiguration` does **not** override config that `Program.cs` reads at startup (the same minimal-hosting gotcha seen in #427). The initial attempt using `ConfigureAppConfiguration` silently no-op'd and broke functional tests; the DI-override approach is reliable.

## Test plan

- ✅ DeviceManager integration: **78/78** (incl. 2 new classes: `RegistrationRateLimitTests` — flood → 429 past the per-IP permit; `RegistrationTokenRequiredTests` — tokenless → 400 when the flag is on)
- ✅ Confirmed no regression in the many functional tests that register multiple devices (base factory keeps the per-IP permit effectively unlimited)
- ✅ Release build + `dotnet format --verify-no-changes` clean

## Deferred (follow-up)

Acceptance item 3 — **prune/expire stale `Pending` devices** that never complete the handshake — is a background-service concern (periodic cleanup job + config) and is intentionally left out to keep this PR focused on the request-surface hardening. #430 stays open for it. Happy to do it next as a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)