### PR TITLE
require OIDC/JWT for operator endpoints; ring-fence plaintext tenant keys

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -34,6 +34,26 @@ Every new endpoint MUST have authentication. The project uses a layered auth mid
 **BundleOrchestrator** — `UseApiKeyAuthentication()` middleware handles: tenant API key → JWT Bearer passthrough
 **IdentityManager** — JWT Bearer only via standard ASP.NET Core middleware
 
+### Operator vs device endpoints (#431)
+
+The middleware chain above only *authenticates* — it does not decide whether a given credential is
+strong enough for a given endpoint. That split is enforced by the `OperatorAccess` authorization
+policy:
+
+- **Operator / control-plane endpoints require a Zitadel JWT.** Approve/reject devices, mint/revoke
+  registration tokens, generate/revoke device keys, device/group/tag management reads and writes,
+  bundle CRUD, bundle assignment, rollout management, and certificate issue/revoke are all annotated
+  with `.RequireAuthorization(AuthorizationPolicies.OperatorAccess)`. The plaintext tenant API key
+  authorizes these **only in non-Production** (the dev/test escape hatch) — in Production only a JWT
+  does. The policy reads the unambiguous `auth_method` claim the middleware stamps on the principal.
+- **Device endpoints keep the hashed device key / mTLS.** The registration handshake
+  (`POST /api/devices`, `registration-status`, `claim-key`), heartbeat, `state`/`current-state`,
+  metrics reporting, `rotate-key`, `reconciliation-status`, `desired-state`, and `sign-csr` are NOT
+  operator-gated — a device authenticates itself with its own credential and must never be able to
+  reach operator endpoints. `OperatorAccessHandler` rejects device credentials outright.
+- Wire the policy with `services.AddOperatorAuthorization(!builder.Environment.IsProduction())` and
+  apply `.RequireAuthorization(AuthorizationPolicies.OperatorAccess)` per endpoint or per group.
+
 **Rules:**
 - Every new endpoint requires auth unless it is a health check, metrics, or explicitly public registration endpoint
 - If an endpoint must be public, annotate with `.AllowAnonymous()` and add a code comment explaining why
@@ -66,7 +86,7 @@ Every new endpoint MUST have authentication. The project uses a layered auth mid
 
 ## API Key Security
 
-- Tenant API keys (MVP): plain config-backed `tenantId:key:scopes` format — acceptable for dev only
+- Tenant API keys (MVP): plain config-backed `tenantId:key:scopes` format — acceptable for dev only, and ring-fenced by the `OperatorAccess` policy so they cannot authorize operator endpoints in Production (#431). Operators authenticate to the control plane via OIDC/JWT.
 - Device API keys: `sb_device_{prefix}_{secret}` format, BCrypt-hashed (work factor 12)
 - Registration tokens: `sbt_{prefix}_{secret}` format, BCrypt-hashed (work factor 12)
 - Key lookup: use the 8-char prefix for DB lookup, then BCrypt verify the full key

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,9 @@
     <!-- Pin MessagePack (pulled transitively by the Aspire AppHost / dashboard) to the
          latest patched 2.5.x release to clear GHSA-hv8m-jj95-wg3x without the 3.x major bump. -->
     <PackageVersion Include="MessagePack" Version="2.5.302" />
+    <!-- Pin Microsoft.OpenApi (pulled transitively via Scalar / AspNetCore.OpenApi) to the first
+         patched release to clear GHSA-v5pm-xwqc-g5wc (NU1903). -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
   <ItemGroup Label="Messaging and CQRS">
     <PackageVersion Include="WolverineFx" Version="5.27.0" />

--- a/docs/operations/cookbooks/onboard-edge-agent-against-cloud.md
+++ b/docs/operations/cookbooks/onboard-edge-agent-against-cloud.md
@@ -43,15 +43,22 @@ curl -sS --http1.1 "$GATEWAY/api/devices"            # -> 401 MISSING_CREDENTIAL
 
 ## 1. (Operator) Generate a registration token
 
-Requires an authenticated admin call. With a tenant API key or dashboard JWT:
+Minting a registration token is an **operator** action, so it requires a Zitadel/OIDC JWT
+(`Authorization: Bearer <jwt>`) — the dashboard already sends one. Grab a token from the dashboard
+session (or an OIDC client-credentials flow) and call:
 
 ```bash
 curl -sS --http1.1 -X POST "$GATEWAY/api/registration-tokens" \
-  -H "X-Api-Key: <admin-tenant-api-key>" \
+  -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"tenantId":"'"$TENANT_ID"'","autoApprove":true}'
 # -> { "token": "sbt_…", ... }   (auto-approve skips the manual approval step)
 ```
+
+> **Auth note (#431):** operator/control-plane endpoints require a JWT. The plaintext
+> `X-Api-Key: <tenant-api-key>` shortcut works **only in non-Production** (a dev/test escape hatch) —
+> in Production it is rejected with `403`. Device endpoints (registration handshake, heartbeat,
+> desired-state, key rotation) still use the device's own credential and are unaffected.
 
 ## 2. (On the Pi) Build & run the agent
 

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleAssignmentEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleAssignmentEndpoints.cs
@@ -1,5 +1,6 @@
 using SignalBeam.BundleOrchestrator.Application.Commands;
 using SignalBeam.BundleOrchestrator.Application.Queries;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 
 namespace SignalBeam.BundleOrchestrator.Host.Endpoints;
 
@@ -16,18 +17,24 @@ public static class BundleAssignmentEndpoints
         var deviceGroup = app.MapGroup("/api/devices")
             .WithTags("Bundle Assignments");
 
+        // Operator action: assigning a bundle to a device is a control-plane write.
         deviceGroup.MapPost("/{deviceId}/bundle", AssignBundleToDevice)
             .WithName("AssignBundleToDevice")
             .WithSummary("Assign bundle to device")
-            .WithDescription("Assigns a specific bundle version to a device, updating its desired state.");
+            .WithDescription("Assigns a specific bundle version to a device, updating its desired state.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
+        // Device action: the agent polls its own desired state to reconcile — keep the existing auth
+        // path (this is the reconcile/desired-state endpoint the device-endpoint carve-out preserves).
         deviceGroup.MapGet("/{deviceId}/desired-state", GetDeviceDesiredState)
             .WithName("GetDeviceDesiredState")
             .WithSummary("Get device desired state")
             .WithDescription("Retrieves the desired bundle state for a specific device.");
 
+        // Operator action: assigning a bundle to a whole group.
         var groupGroup = app.MapGroup("/api/device-groups")
-            .WithTags("Bundle Assignments");
+            .WithTags("Bundle Assignments")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         groupGroup.MapPost("/{deviceGroupId}/bundle", AssignBundleToGroup)
             .WithName("AssignBundleToGroup")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleEndpoints.cs
@@ -2,6 +2,7 @@ using SignalBeam.BundleOrchestrator.Application.Commands;
 using SignalBeam.BundleOrchestrator.Application.Models;
 using SignalBeam.BundleOrchestrator.Application.Queries;
 using SignalBeam.Shared.Infrastructure.Authentication;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 
 namespace SignalBeam.BundleOrchestrator.Host.Endpoints;
 
@@ -59,8 +60,11 @@ public static class BundleEndpoints
     /// </summary>
     public static IEndpointRouteBuilder MapBundleEndpoints(this IEndpointRouteBuilder app)
     {
+        // Bundle CRUD is an operator/dashboard concern — require a JWT (dev/test tenant-key hatch).
+        // The agent never reads bundles directly; it reconciles from GET /api/devices/{id}/desired-state.
         var group = app.MapGroup("/api/bundles")
-            .WithTags("Bundles");
+            .WithTags("Bundles")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPost("/", CreateBundle)
             .WithName("CreateBundle")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleVersionEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/BundleVersionEndpoints.cs
@@ -4,6 +4,7 @@ using SignalBeam.BundleOrchestrator.Application.Queries;
 using SignalBeam.BundleOrchestrator.Application.Repositories;
 using SignalBeam.BundleOrchestrator.Application.Storage;
 using SignalBeam.Domain.ValueObjects;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 
 namespace SignalBeam.BundleOrchestrator.Host.Endpoints;
 
@@ -17,8 +18,11 @@ public static class BundleVersionEndpoints
     /// </summary>
     public static IEndpointRouteBuilder MapBundleVersionEndpoints(this IEndpointRouteBuilder app)
     {
+        // Bundle-version management/reads are operator/dashboard-facing. The agent never calls these
+        // — it reconciles from the inline definition returned by GET /api/devices/{id}/desired-state.
         var group = app.MapGroup("/api/bundles/{bundleId}/versions")
-            .WithTags("Bundle Versions");
+            .WithTags("Bundle Versions")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPost("/", CreateBundleVersion)
             .WithName("CreateBundleVersion")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/PhasedRolloutEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/PhasedRolloutEndpoints.cs
@@ -1,5 +1,6 @@
 using SignalBeam.BundleOrchestrator.Application.Commands;
 using SignalBeam.BundleOrchestrator.Application.Queries;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 using SignalBeam.Shared.Infrastructure.Results;
 
 namespace SignalBeam.BundleOrchestrator.Host.Endpoints;
@@ -14,8 +15,10 @@ public static class PhasedRolloutEndpoints
     /// </summary>
     public static IEndpointRouteBuilder MapPhasedRolloutEndpoints(this IEndpointRouteBuilder app)
     {
+        // Phased-rollout management is operator-only.
         var group = app.MapGroup("/api/phased-rollouts")
-            .WithTags("Phased Rollouts");
+            .WithTags("Phased Rollouts")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         // Query endpoints
         group.MapGet("", ListPhasedRollouts)

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/RolloutEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/RolloutEndpoints.cs
@@ -1,5 +1,6 @@
 using SignalBeam.BundleOrchestrator.Application.Commands;
 using SignalBeam.BundleOrchestrator.Application.Queries;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 
 namespace SignalBeam.BundleOrchestrator.Host.Endpoints;
 
@@ -13,8 +14,11 @@ public static class RolloutEndpoints
     /// </summary>
     public static IEndpointRouteBuilder MapRolloutEndpoints(this IEndpointRouteBuilder app)
     {
+        // Rollout management is operator-only — the agent reports reconciliation status but never
+        // drives rollouts.
         var group = app.MapGroup("/api/rollouts")
-            .WithTags("Rollouts");
+            .WithTags("Rollouts")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapGet("", GetRollouts)
             .WithName("GetRollouts")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/RolloutStatusEndpoints.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Endpoints/RolloutStatusEndpoints.cs
@@ -1,5 +1,6 @@
 using SignalBeam.BundleOrchestrator.Application.Commands;
 using SignalBeam.BundleOrchestrator.Application.Queries;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 
 namespace SignalBeam.BundleOrchestrator.Host.Endpoints;
 
@@ -13,8 +14,10 @@ public static class RolloutStatusEndpoints
     /// </summary>
     public static IEndpointRouteBuilder MapRolloutStatusEndpoints(this IEndpointRouteBuilder app)
     {
+        // Rollout-status reads are operator/dashboard-facing.
         var group = app.MapGroup("/api/rollouts")
-            .WithTags("Rollout Status");
+            .WithTags("Rollout Status")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapGet("/bundles/{bundleId}", GetRolloutStatus)
             .WithName("GetRolloutStatus")

--- a/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Program.cs
+++ b/src/BundleOrchestrator/SignalBeam.BundleOrchestrator.Host/Program.cs
@@ -10,6 +10,7 @@ using Serilog;
 using SignalBeam.ServiceDefaults;
 using Scalar.AspNetCore;
 using SignalBeam.Shared.Infrastructure.Authentication;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.OpenApi;
 using Microsoft.EntityFrameworkCore;
@@ -62,7 +63,10 @@ builder.Services.AddAuthentication(options =>
     };
 });
 
-builder.Services.AddAuthorization();
+// Operator/control-plane endpoints (bundle CRUD, assignment, rollouts) require a Zitadel JWT.
+// Outside Production the plaintext tenant API key is also accepted (dev/test escape hatch); in
+// Production only the JWT authorizes. (#431)
+builder.Services.AddOperatorAuthorization(!builder.Environment.IsProduction());
 
 // Add Rate Limiting
 builder.Services.AddRateLimiter(options =>

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/CertificateEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/CertificateEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Queries;
 using SignalBeam.DeviceManager.Application.Services;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 
 namespace SignalBeam.DeviceManager.Host.Endpoints;
 
@@ -23,11 +24,14 @@ public static class CertificateEndpoints
         var group = app.MapGroup("/api/certificates")
             .WithTags("Certificates");
 
+        // Operator action: minting a certificate for a device is a control-plane operation.
         group.MapPost("/{deviceId:guid}/issue", IssueCertificate)
             .WithName("IssueCertificate")
             .WithSummary("Issue a new certificate for an approved device")
-            .WithDescription("Generates and issues a new mTLS client certificate for an approved device.");
+            .WithDescription("Generates and issues a new mTLS client certificate for an approved device.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
+        // Device action: the agent signs its own CSR during enrolment — keep the existing auth path.
         group.MapPost("/{deviceId:guid}/sign-csr", SignDeviceCsr)
             .WithName("SignDeviceCsr")
             .WithSummary("Sign a device-generated CSR")
@@ -42,12 +46,14 @@ public static class CertificateEndpoints
         group.MapDelete("/{serialNumber}", RevokeCertificate)
             .WithName("RevokeCertificate")
             .WithSummary("Revoke a device certificate")
-            .WithDescription("Revokes a certificate, preventing further authentication with it.");
+            .WithDescription("Revokes a certificate, preventing further authentication with it.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapGet("/device/{deviceId:guid}", GetDeviceCertificates)
             .WithName("GetDeviceCertificates")
             .WithSummary("Get all certificates for a device")
-            .WithDescription("Retrieves all certificates (active and revoked) for a specific device.");
+            .WithDescription("Retrieves all certificates (active and revoked) for a specific device.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         // Public endpoint - no authentication required
         group.MapGet("/ca", GetCaCertificate)

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/DeviceEndpoints.cs
@@ -3,6 +3,7 @@ using SignalBeam.DeviceManager.Application.Queries;
 using SignalBeam.DeviceManager.Infrastructure.Queries;
 using SignalBeam.Domain.Enums;
 using SignalBeam.Shared.Infrastructure.Authentication;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 using SignalBeam.Shared.Infrastructure.Results;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -57,27 +58,32 @@ public static class DeviceEndpoints
         group.MapGet("/", GetDevices)
             .WithName("GetDevices")
             .WithSummary("Get devices with filters")
-            .WithDescription("Retrieves a paginated list of devices with optional filters.");
+            .WithDescription("Retrieves a paginated list of devices with optional filters.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapGet("/by-status/{status}", GetDevicesByRegistrationStatus)
             .WithName("GetDevicesByRegistrationStatus")
             .WithSummary("Get devices by registration status")
-            .WithDescription("Retrieves devices filtered by registration status (Pending, Approved, Rejected).");
+            .WithDescription("Retrieves devices filtered by registration status (Pending, Approved, Rejected).")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapGet("/{deviceId:guid}", GetDeviceById)
             .WithName("GetDeviceById")
             .WithSummary("Get device by ID")
-            .WithDescription("Retrieves detailed information about a specific device.");
+            .WithDescription("Retrieves detailed information about a specific device.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPut("/{deviceId:guid}", UpdateDevice)
             .WithName("UpdateDevice")
             .WithSummary("Update device")
-            .WithDescription("Updates device name and/or metadata.");
+            .WithDescription("Updates device name and/or metadata.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPost("/{deviceId:guid}/tags", AddDeviceTag)
             .WithName("AddDeviceTag")
             .WithSummary("Add tag to device")
-            .WithDescription("Adds a tag to a device for categorization.");
+            .WithDescription("Adds a tag to a device for categorization.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPost("/{deviceId:guid}/heartbeat", RecordHeartbeat)
             .WithName("RecordHeartbeat")
@@ -87,7 +93,8 @@ public static class DeviceEndpoints
         group.MapPut("/{deviceId:guid}/group", AssignDeviceToGroup)
             .WithName("AssignDeviceToGroup")
             .WithSummary("Assign device to group")
-            .WithDescription("Assigns a device to a device group or removes it from a group.");
+            .WithDescription("Assigns a device to a device group or removes it from a group.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPost("/{deviceId:guid}/state", ReportDeviceState)
             .WithName("ReportDeviceState")
@@ -97,12 +104,14 @@ public static class DeviceEndpoints
         group.MapGet("/{deviceId:guid}/health", GetDeviceHealth)
             .WithName("GetDeviceHealth")
             .WithSummary("Get device health")
-            .WithDescription("Retrieves health information about a specific device.");
+            .WithDescription("Retrieves health information about a specific device.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapGet("/groups/{deviceGroupId:guid}", GetDevicesByGroup)
             .WithName("GetDevicesByGroup")
             .WithSummary("Get devices by group")
-            .WithDescription("Retrieves all devices in a specific device group with optional filters.");
+            .WithDescription("Retrieves all devices in a specific device group with optional filters.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPost("/{deviceId:guid}/metrics", UpdateDeviceMetrics)
             .WithName("UpdateDeviceMetrics")
@@ -112,23 +121,27 @@ public static class DeviceEndpoints
         group.MapGet("/{deviceId:guid}/metrics", GetDeviceMetrics)
             .WithName("GetDeviceMetrics")
             .WithSummary("Get device metrics history")
-            .WithDescription("Retrieves historical metrics data for a device with optional date range filtering.");
+            .WithDescription("Retrieves historical metrics data for a device with optional date range filtering.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapGet("/{deviceId:guid}/activity-log", GetDeviceActivityLog)
             .WithName("GetDeviceActivityLog")
             .WithSummary("Get device activity log")
-            .WithDescription("Retrieves the activity log for a specific device.");
+            .WithDescription("Retrieves the activity log for a specific device.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         // Device registration approval and API key management
         group.MapPost("/{deviceId:guid}/approve", ApproveDeviceRegistration)
             .WithName("ApproveDeviceRegistration")
             .WithSummary("Approve device registration")
-            .WithDescription("Approves a pending device registration and generates an API key.");
+            .WithDescription("Approves a pending device registration and generates an API key.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPost("/{deviceId:guid}/reject", RejectDeviceRegistration)
             .WithName("RejectDeviceRegistration")
             .WithSummary("Reject device registration")
-            .WithDescription("Rejects a pending device registration.");
+            .WithDescription("Rejects a pending device registration.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPost("/{deviceId:guid}/claim-key", ClaimDeviceApiKey)
             .WithName("ClaimDeviceApiKey")
@@ -141,7 +154,8 @@ public static class DeviceEndpoints
         group.MapPost("/{deviceId:guid}/api-keys", GenerateDeviceApiKey)
             .WithName("GenerateDeviceApiKey")
             .WithSummary("Generate device API key")
-            .WithDescription("Generates a new API key for a device (for key rotation).");
+            .WithDescription("Generates a new API key for a device (for key rotation).")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapPost("/{deviceId:guid}/rotate-key", RotateDeviceApiKey)
             .WithName("RotateDeviceApiKey")
@@ -152,11 +166,14 @@ public static class DeviceEndpoints
         group.MapDelete("/api-keys/{apiKeyId:guid}", RevokeDeviceApiKey)
             .WithName("RevokeDeviceApiKey")
             .WithSummary("Revoke device API key")
-            .WithDescription("Revokes an existing device API key.");
+            .WithDescription("Revokes an existing device API key.")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
-        // Registration token management
+        // Registration token management — operator-only (minting tokens is the highest-value
+        // control-plane action). Requires a JWT; the plaintext tenant key only works in dev/test.
         var tokenGroup = app.MapGroup("/api/registration-tokens")
-            .WithTags("Registration Tokens");
+            .WithTags("Registration Tokens")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         tokenGroup.MapPost("/", GenerateRegistrationToken)
             .WithName("GenerateRegistrationToken")

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/GroupEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/GroupEndpoints.cs
@@ -1,6 +1,7 @@
 using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Queries;
 using SignalBeam.Shared.Infrastructure.Authentication;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace SignalBeam.DeviceManager.Host.Endpoints;
@@ -15,8 +16,10 @@ public static class GroupEndpoints
     /// </summary>
     public static IEndpointRouteBuilder MapGroupEndpoints(this IEndpointRouteBuilder app)
     {
+        // Device-group management is entirely an operator concern — devices never call it.
         var group = app.MapGroup("/api/groups")
-            .WithTags("Device Groups");
+            .WithTags("Device Groups")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapGet("/", GetDeviceGroups)
             .WithName("GetDeviceGroups")

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/TagEndpoints.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Endpoints/TagEndpoints.cs
@@ -1,5 +1,6 @@
 using SignalBeam.DeviceManager.Application.Commands;
 using SignalBeam.DeviceManager.Application.Queries;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace SignalBeam.DeviceManager.Host.Endpoints;
@@ -14,8 +15,10 @@ public static class TagEndpoints
     /// </summary>
     public static IEndpointRouteBuilder MapTagEndpoints(this IEndpointRouteBuilder app)
     {
+        // Tag management and tag-search are operator/dashboard features — devices never call them.
         var group = app.MapGroup("/api/tags")
-            .WithTags("Tags");
+            .WithTags("Tags")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         group.MapGet("/", GetAllTags)
             .WithName("GetAllTags")
@@ -28,7 +31,8 @@ public static class TagEndpoints
             .WithDescription("Removes a specific tag from a device.");
 
         var searchGroup = app.MapGroup("/api/devices")
-            .WithTags("Devices");
+            .WithTags("Devices")
+            .RequireAuthorization(AuthorizationPolicies.OperatorAccess);
 
         searchGroup.MapGet("/search", SearchDevicesByTagQuery)
             .WithName("SearchDevicesByTagQuery")

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/Program.cs
@@ -11,6 +11,7 @@ using Serilog;
 using SignalBeam.ServiceDefaults;
 using Scalar.AspNetCore;
 using SignalBeam.Shared.Infrastructure.Authentication;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.OpenApi;
 using Microsoft.EntityFrameworkCore;
@@ -83,7 +84,10 @@ builder.Services.AddAuthentication(options =>
     };
 });
 
-builder.Services.AddAuthorization();
+// Operator/control-plane endpoints require a Zitadel JWT. Outside Production the plaintext tenant
+// API key is also accepted (dev/test escape hatch) so local dev and the integration suite work
+// without a running OIDC provider; in Production only the JWT authorizes. (#431)
+builder.Services.AddOperatorAuthorization(!builder.Environment.IsProduction());
 
 // Add Rate Limiting. Limits are configurable (RateLimiting:*) so they can be tuned per
 // environment and made deterministic in tests; the defaults preserve the original behaviour.

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/ApiKeyAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/ApiKeyAuthenticationMiddleware.cs
@@ -48,6 +48,11 @@ public class ApiKeyAuthenticationMiddleware
             var jwtResult = await context.AuthenticateAsync(AuthenticationConstants.JwtBearerScheme);
             if (jwtResult.Succeeded && jwtResult.Principal is not null)
             {
+                if (jwtResult.Principal.Identity is ClaimsIdentity jwtIdentity)
+                {
+                    jwtIdentity.AddClaim(new Claim(
+                        AuthenticationConstants.AuthMethodClaimType, AuthenticationConstants.AuthMethodJwt));
+                }
                 context.User = jwtResult.Principal;
                 await _next(context);
                 return;
@@ -103,7 +108,11 @@ public class ApiKeyAuthenticationMiddleware
         var claims = new List<Claim>
         {
             new(AuthenticationConstants.TenantIdClaimType, result.TenantId),
-            new(ClaimTypes.AuthenticationMethod, AuthenticationConstants.ApiKeyScheme)
+            new(ClaimTypes.AuthenticationMethod, AuthenticationConstants.ApiKeyScheme),
+            // This middleware only validates the config-backed tenant key (no device keys), so the
+            // API-key path here is always a tenant key — tag it so the operator policy treats it as
+            // the dev-only escape hatch.
+            new(AuthenticationConstants.AuthMethodClaimType, AuthenticationConstants.AuthMethodTenantApiKey)
         };
 
         foreach (var scope in result.Scopes)

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/ApiKeyAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/ApiKeyAuthenticationMiddleware.cs
@@ -48,11 +48,7 @@ public class ApiKeyAuthenticationMiddleware
             var jwtResult = await context.AuthenticateAsync(AuthenticationConstants.JwtBearerScheme);
             if (jwtResult.Succeeded && jwtResult.Principal is not null)
             {
-                if (jwtResult.Principal.Identity is ClaimsIdentity jwtIdentity)
-                {
-                    jwtIdentity.AddClaim(new Claim(
-                        AuthenticationConstants.AuthMethodClaimType, AuthenticationConstants.AuthMethodJwt));
-                }
+                AuthMethodClaimStamp.Apply(jwtResult.Principal, AuthenticationConstants.AuthMethodJwt);
                 context.User = jwtResult.Principal;
                 await _next(context);
                 return;

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/AuthMethodClaimStamp.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/AuthMethodClaimStamp.cs
@@ -1,0 +1,38 @@
+using System.Security.Claims;
+
+namespace SignalBeam.Shared.Infrastructure.Authentication;
+
+/// <summary>
+/// Stamps the authoritative <see cref="AuthenticationConstants.AuthMethodClaimType"/> claim on a
+/// principal after authentication, so authorization policies can trust it.
+/// </summary>
+public static class AuthMethodClaimStamp
+{
+    /// <summary>
+    /// Records how the caller authenticated. Any pre-existing <c>auth_method</c> claim is stripped
+    /// first so the middleware value is authoritative: a JWT payload could itself carry an
+    /// <c>auth_method</c> claim (e.g. a Zitadel custom claim), and <see cref="ClaimsPrincipal.FindFirst"/>
+    /// returns the FIRST match — which would be the untrusted payload value, not ours. Fail-closed:
+    /// the authorization handler can only ever see the value the middleware decided.
+    /// </summary>
+    public static void Apply(ClaimsPrincipal principal, string method)
+    {
+        foreach (var identity in principal.Identities)
+        {
+            foreach (var existing in identity.FindAll(AuthenticationConstants.AuthMethodClaimType).ToList())
+            {
+                identity.RemoveClaim(existing);
+            }
+        }
+
+        if (principal.Identity is ClaimsIdentity primary)
+        {
+            primary.AddClaim(new Claim(AuthenticationConstants.AuthMethodClaimType, method));
+        }
+        else
+        {
+            principal.AddIdentity(new ClaimsIdentity(
+                new[] { new Claim(AuthenticationConstants.AuthMethodClaimType, method) }));
+        }
+    }
+}

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/AuthenticationConstants.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/AuthenticationConstants.cs
@@ -49,4 +49,24 @@ public static class AuthenticationConstants
     /// Certificate (mTLS) authentication scheme name.
     /// </summary>
     public const string CertificateScheme = "Certificate";
+
+    /// <summary>
+    /// Claim type identifying how the caller authenticated. Set by the auth middleware to an
+    /// unambiguous value (see the <c>AuthMethod*</c> constants) so authorization policies can
+    /// distinguish an operator JWT from a device or tenant API key regardless of the ClaimsIdentity
+    /// scheme name (which overloads "ApiKey" between device and tenant keys).
+    /// </summary>
+    public const string AuthMethodClaimType = "auth_method";
+
+    /// <summary>Operator authenticated via a Zitadel/OIDC JWT.</summary>
+    public const string AuthMethodJwt = "Jwt";
+
+    /// <summary>Caller authenticated via a config-backed plaintext tenant API key (dev-only).</summary>
+    public const string AuthMethodTenantApiKey = "TenantApiKey";
+
+    /// <summary>Device authenticated via a hashed device API key (<c>sb_device_*</c>).</summary>
+    public const string AuthMethodDeviceApiKey = "DeviceApiKey";
+
+    /// <summary>Device authenticated via a client certificate (mTLS).</summary>
+    public const string AuthMethodCertificate = "Certificate";
 }

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/AuthorizationPolicies.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/AuthorizationPolicies.cs
@@ -1,0 +1,16 @@
+namespace SignalBeam.Shared.Infrastructure.Authentication.Authorization;
+
+/// <summary>
+/// Named authorization policies applied to endpoints via <c>.RequireAuthorization(...)</c>.
+/// </summary>
+public static class AuthorizationPolicies
+{
+    /// <summary>
+    /// Gate for operator / control-plane endpoints (approve/reject devices, mint registration
+    /// tokens, bundle CRUD, rollouts). Requires a Zitadel/OIDC JWT; the plaintext tenant API key
+    /// only satisfies it under the dev-only escape hatch. Device endpoints (heartbeat,
+    /// desired-state, key rotation, certificate flows) are NOT gated by this — they keep the
+    /// hashed device API key / mTLS path.
+    /// </summary>
+    public const string OperatorAccess = "OperatorAccess";
+}

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/OperatorAccessHandler.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/OperatorAccessHandler.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace SignalBeam.Shared.Infrastructure.Authentication.Authorization;
+
+/// <summary>
+/// Evaluates <see cref="OperatorAccessRequirement"/> against the caller's authentication method,
+/// which the auth middleware records as the <see cref="AuthenticationConstants.AuthMethodClaimType"/>
+/// claim. Reading that claim (rather than the ClaimsIdentity scheme name) avoids the "ApiKey"
+/// overload between device-specific and tenant keys.
+/// </summary>
+public sealed class OperatorAccessHandler : AuthorizationHandler<OperatorAccessRequirement>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        OperatorAccessRequirement requirement)
+    {
+        var authMethod = context.User
+            .FindFirst(AuthenticationConstants.AuthMethodClaimType)?.Value;
+
+        var authorized = authMethod switch
+        {
+            // Operator authenticated via OIDC — always allowed.
+            AuthenticationConstants.AuthMethodJwt => true,
+            // Plaintext tenant key — allowed only under the dev/test escape hatch.
+            AuthenticationConstants.AuthMethodTenantApiKey => requirement.AllowTenantApiKeyFallback,
+            // Device credentials (hashed key, mTLS) and anonymous callers can never reach operator
+            // endpoints — a device must not be able to approve/reject devices or mint tokens.
+            _ => false
+        };
+
+        if (authorized)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/OperatorAccessRequirement.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/OperatorAccessRequirement.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace SignalBeam.Shared.Infrastructure.Authentication.Authorization;
+
+/// <summary>
+/// Requires an operator-grade credential. A Zitadel/OIDC JWT always satisfies it; the config-backed
+/// plaintext tenant API key satisfies it only when <see cref="AllowTenantApiKeyFallback"/> is set —
+/// the dev/test escape hatch. Device credentials (hashed API key, certificate) never satisfy it.
+/// </summary>
+public sealed class OperatorAccessRequirement : IAuthorizationRequirement
+{
+    public OperatorAccessRequirement(bool allowTenantApiKeyFallback)
+    {
+        AllowTenantApiKeyFallback = allowTenantApiKeyFallback;
+    }
+
+    /// <summary>
+    /// When true (non-Production), a plaintext tenant API key also authorizes operator endpoints so
+    /// local development and the integration test suite work without a running OIDC provider. In
+    /// Production this is false, so only a JWT authorizes — the plaintext key is ring-fenced out.
+    /// </summary>
+    public bool AllowTenantApiKeyFallback { get; }
+}

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/OperatorAuthorizationExtensions.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/OperatorAuthorizationExtensions.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SignalBeam.Shared.Infrastructure.Authentication.Authorization;
+
+/// <summary>
+/// DI wiring for the operator-access authorization policy.
+/// </summary>
+public static class OperatorAuthorizationExtensions
+{
+    /// <summary>
+    /// Registers authorization with the <see cref="AuthorizationPolicies.OperatorAccess"/> policy and
+    /// its handler. Replaces the bare <c>services.AddAuthorization()</c> call.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="allowTenantApiKeyFallback">
+    /// Pass <c>!env.IsProduction()</c>. When true, the plaintext tenant API key also authorizes
+    /// operator endpoints (dev/test escape hatch); in Production only a JWT does.
+    /// </param>
+    public static IServiceCollection AddOperatorAuthorization(
+        this IServiceCollection services,
+        bool allowTenantApiKeyFallback)
+    {
+        services.AddSingleton<Microsoft.AspNetCore.Authorization.IAuthorizationHandler, OperatorAccessHandler>();
+
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy(AuthorizationPolicies.OperatorAccess, policy =>
+            {
+                policy.RequireAuthenticatedUser();
+                policy.AddRequirements(new OperatorAccessRequirement(allowTenantApiKeyFallback));
+            });
+        });
+
+        return services;
+    }
+}

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/OperatorAuthorizationExtensions.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/OperatorAuthorizationExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace SignalBeam.Shared.Infrastructure.Authentication.Authorization;
 
@@ -20,7 +21,9 @@ public static class OperatorAuthorizationExtensions
         this IServiceCollection services,
         bool allowTenantApiKeyFallback)
     {
-        services.AddSingleton<Microsoft.AspNetCore.Authorization.IAuthorizationHandler, OperatorAccessHandler>();
+        // TryAdd so a second call (e.g. a test overriding the policy via ConfigureTestServices to
+        // simulate Production) doesn't accumulate duplicate handler instances in the container.
+        services.TryAddSingleton<Microsoft.AspNetCore.Authorization.IAuthorizationHandler, OperatorAccessHandler>();
 
         services.AddAuthorization(options =>
         {

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
@@ -98,7 +98,7 @@ public class DeviceAuthenticationMiddleware
             var jwtResult = await context.AuthenticateAsync(AuthenticationConstants.JwtBearerScheme);
             if (jwtResult.Succeeded && jwtResult.Principal is not null)
             {
-                TagAuthMethod(jwtResult.Principal, AuthenticationConstants.AuthMethodJwt);
+                AuthMethodClaimStamp.Apply(jwtResult.Principal, AuthenticationConstants.AuthMethodJwt);
                 context.User = jwtResult.Principal;
                 await _next(context);
                 return;
@@ -351,24 +351,6 @@ public class DeviceAuthenticationMiddleware
         context.Items["TenantId"] = result.TenantId;
         context.Items["AuthenticationMethod"] = "TenantApiKey";
         context.Items["Scopes"] = result.Scopes;
-    }
-
-    /// <summary>
-    /// Records how the caller authenticated on the principal so authorization policies can tell an
-    /// operator JWT apart from a device or tenant key. Adds the claim to the primary identity when it
-    /// is mutable, otherwise attaches a lightweight marker identity.
-    /// </summary>
-    private static void TagAuthMethod(ClaimsPrincipal principal, string method)
-    {
-        if (principal.Identity is ClaimsIdentity identity)
-        {
-            identity.AddClaim(new Claim(AuthenticationConstants.AuthMethodClaimType, method));
-        }
-        else
-        {
-            principal.AddIdentity(new ClaimsIdentity(
-                new[] { new Claim(AuthenticationConstants.AuthMethodClaimType, method) }));
-        }
     }
 
     private async Task RespondUnauthorized(

--- a/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
+++ b/src/Shared/SignalBeam.Shared.Infrastructure/Authentication/DeviceAuthenticationMiddleware.cs
@@ -98,6 +98,7 @@ public class DeviceAuthenticationMiddleware
             var jwtResult = await context.AuthenticateAsync(AuthenticationConstants.JwtBearerScheme);
             if (jwtResult.Succeeded && jwtResult.Principal is not null)
             {
+                TagAuthMethod(jwtResult.Principal, AuthenticationConstants.AuthMethodJwt);
                 context.User = jwtResult.Principal;
                 await _next(context);
                 return;
@@ -298,11 +299,19 @@ public class DeviceAuthenticationMiddleware
         dynamic result, // Can be from either validator
         AuthenticationMethod method)
     {
+        // Unambiguous auth-method marker for authorization policies. Device credentials (hashed key
+        // or certificate) must never satisfy the operator policy, so tag them distinctly rather than
+        // reusing the overloaded ClaimsIdentity scheme name.
+        var authMethodValue = method == AuthenticationMethod.Certificate
+            ? AuthenticationConstants.AuthMethodCertificate
+            : AuthenticationConstants.AuthMethodDeviceApiKey;
+
         var claims = new List<Claim>
         {
             new(AuthenticationConstants.DeviceIdClaimType, result.DeviceId.ToString()),
             new(AuthenticationConstants.TenantIdClaimType, result.TenantId.ToString()),
-            new(ClaimTypes.AuthenticationMethod, method.ToString())
+            new(ClaimTypes.AuthenticationMethod, method.ToString()),
+            new(AuthenticationConstants.AuthMethodClaimType, authMethodValue)
         };
 
         var schemeName = method == AuthenticationMethod.Certificate
@@ -325,7 +334,8 @@ public class DeviceAuthenticationMiddleware
         var claims = new List<Claim>
         {
             new(AuthenticationConstants.TenantIdClaimType, result.TenantId),
-            new(ClaimTypes.AuthenticationMethod, "TenantApiKey")
+            new(ClaimTypes.AuthenticationMethod, "TenantApiKey"),
+            new(AuthenticationConstants.AuthMethodClaimType, AuthenticationConstants.AuthMethodTenantApiKey)
         };
 
         // Add scopes as claims
@@ -341,6 +351,24 @@ public class DeviceAuthenticationMiddleware
         context.Items["TenantId"] = result.TenantId;
         context.Items["AuthenticationMethod"] = "TenantApiKey";
         context.Items["Scopes"] = result.Scopes;
+    }
+
+    /// <summary>
+    /// Records how the caller authenticated on the principal so authorization policies can tell an
+    /// operator JWT apart from a device or tenant key. Adds the claim to the primary identity when it
+    /// is mutable, otherwise attaches a lightweight marker identity.
+    /// </summary>
+    private static void TagAuthMethod(ClaimsPrincipal principal, string method)
+    {
+        if (principal.Identity is ClaimsIdentity identity)
+        {
+            identity.AddClaim(new Claim(AuthenticationConstants.AuthMethodClaimType, method));
+        }
+        else
+        {
+            principal.AddIdentity(new ClaimsIdentity(
+                new[] { new Claim(AuthenticationConstants.AuthMethodClaimType, method) }));
+        }
     }
 
     private async Task RespondUnauthorized(

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/OperatorEndpointAuthorizationTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/OperatorEndpointAuthorizationTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using SignalBeam.DeviceManager.Application.Commands;
+using SignalBeam.DeviceManager.Tests.Integration.Infrastructure;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
+
+namespace SignalBeam.DeviceManager.Tests.Integration;
+
+/// <summary>
+/// Verifies the operator-vs-device auth split (#431): operator endpoints require a JWT and the
+/// plaintext tenant API key only authorizes them under the dev/test escape hatch, while the device
+/// registration handshake and device-key endpoints are unaffected.
+/// </summary>
+public class OperatorEndpointAuthorizationTests : IClassFixture<DeviceManagerWebApplicationFactory>
+{
+    private readonly DeviceManagerWebApplicationFactory _factory;
+
+    public OperatorEndpointAuthorizationTests(DeviceManagerWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    /// <summary>
+    /// Reconfigures the operator policy with the tenant-key fallback DISABLED, i.e. as it behaves in
+    /// Production. ConfigureTestServices runs after the app's own registration, so this later
+    /// AddOperatorAuthorization(false) overwrites the "OperatorAccess" policy in the map.
+    /// </summary>
+    private HttpClient CreateProductionLikeClient(string apiKey = "operator-key")
+    {
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddOperatorAuthorization(allowTenantApiKeyFallback: false);
+            });
+        }).CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", apiKey);
+        return client;
+    }
+
+    [Fact]
+    public async Task OperatorEndpoint_WithTenantKey_InProduction_IsForbidden()
+    {
+        // Arrange — a plaintext tenant key that the middleware still validates, but which must NOT
+        // authorize an operator endpoint once the dev hatch is off.
+        var client = CreateProductionLikeClient();
+
+        // Act — list devices is an operator/dashboard read.
+        var response = await client.GetAsync("/api/devices?tenantId=" + _factory.DefaultTenantId);
+
+        // Assert — authenticated (tenant principal set) but not operator-authorized -> 403.
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task RegistrationTokenMint_WithTenantKey_InProduction_IsForbidden()
+    {
+        // Minting registration tokens is the highest-value control-plane action — the tenant key
+        // must never authorize it outside dev.
+        var client = CreateProductionLikeClient();
+
+        var response = await client.PostAsJsonAsync("/api/registration-tokens", new
+        {
+            tenantId = _factory.DefaultTenantId,
+            description = "should be rejected"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task OperatorEndpoint_WithTenantKey_InDev_IsAllowed()
+    {
+        // The default test factory keeps the dev/test escape hatch on, so the tenant key still works
+        // for operator endpoints — this is what keeps local dev and the existing suite green.
+        var client = _factory.CreateAuthenticatedClient("operator-key");
+
+        var response = await client.GetAsync("/api/devices?tenantId=" + _factory.DefaultTenantId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task DeviceRegistrationHandshake_StaysOpen_EvenInProduction()
+    {
+        // The anonymous device handshake is NOT an operator endpoint — ring-fencing the tenant key
+        // must not break a brand-new device registering itself.
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+                services.AddOperatorAuthorization(allowTenantApiKeyFallback: false));
+        }).CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/devices", new RegisterDeviceCommand(
+            TenantId: _factory.DefaultTenantId,
+            DeviceId: Guid.NewGuid(),
+            Name: "handshake-device"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task OperatorEndpoint_WithNoCredentials_IsUnauthorized()
+    {
+        // No credentials at all is rejected by the auth middleware before authorization runs.
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/devices?tenantId=" + _factory.DefaultTenantId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/SignalBeam.Shared.Infrastructure.Tests/Authentication/AuthMethodClaimStampTests.cs
+++ b/tests/SignalBeam.Shared.Infrastructure.Tests/Authentication/AuthMethodClaimStampTests.cs
@@ -1,0 +1,40 @@
+using System.Security.Claims;
+using FluentAssertions;
+using SignalBeam.Shared.Infrastructure.Authentication;
+
+namespace SignalBeam.Shared.Infrastructure.Tests.Authentication;
+
+/// <summary>
+/// The operator-access gate trusts the middleware-stamped <c>auth_method</c> claim. A JWT payload
+/// could itself carry that claim (a Zitadel custom claim), so the stamp must be authoritative:
+/// FindFirst must return the middleware value, never a pre-existing untrusted one.
+/// </summary>
+public class AuthMethodClaimStampTests
+{
+    [Fact]
+    public void Apply_overrides_a_preexisting_auth_method_claim_from_the_token()
+    {
+        // A JWT-style identity that already carries a (hostile) auth_method claim.
+        var identity = new ClaimsIdentity(
+            new[] { new Claim(AuthenticationConstants.AuthMethodClaimType, AuthenticationConstants.AuthMethodTenantApiKey) },
+            authenticationType: "Bearer");
+        var principal = new ClaimsPrincipal(identity);
+
+        AuthMethodClaimStamp.Apply(principal, AuthenticationConstants.AuthMethodJwt);
+
+        principal.FindAll(AuthenticationConstants.AuthMethodClaimType)
+            .Should().ContainSingle("the stamp must be the only auth_method claim")
+            .Which.Value.Should().Be(AuthenticationConstants.AuthMethodJwt);
+    }
+
+    [Fact]
+    public void Apply_stamps_when_no_claim_exists()
+    {
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(Array.Empty<Claim>(), "Bearer"));
+
+        AuthMethodClaimStamp.Apply(principal, AuthenticationConstants.AuthMethodJwt);
+
+        principal.FindFirst(AuthenticationConstants.AuthMethodClaimType)!.Value
+            .Should().Be(AuthenticationConstants.AuthMethodJwt);
+    }
+}

--- a/tests/SignalBeam.Shared.Infrastructure.Tests/Authentication/OperatorAccessHandlerTests.cs
+++ b/tests/SignalBeam.Shared.Infrastructure.Tests/Authentication/OperatorAccessHandlerTests.cs
@@ -1,0 +1,71 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using SignalBeam.Shared.Infrastructure.Authentication;
+using SignalBeam.Shared.Infrastructure.Authentication.Authorization;
+
+namespace SignalBeam.Shared.Infrastructure.Tests.Authentication;
+
+/// <summary>
+/// Unit tests for the operator-access gate (#431). Operator endpoints must accept a Zitadel/OIDC
+/// JWT, accept the plaintext tenant API key ONLY under the dev/test escape hatch, and never accept a
+/// device credential or an anonymous caller — a device must not be able to approve devices or mint
+/// registration tokens.
+/// </summary>
+public class OperatorAccessHandlerTests
+{
+    private static async Task<bool> Evaluate(string? authMethod, bool allowTenantApiKeyFallback)
+    {
+        var claims = authMethod is null
+            ? Array.Empty<Claim>()
+            : new[] { new Claim(AuthenticationConstants.AuthMethodClaimType, authMethod) };
+
+        // An authenticated identity requires a non-null authentication type.
+        var identity = new ClaimsIdentity(claims, authenticationType: authMethod is null ? null : "test");
+        var user = new ClaimsPrincipal(identity);
+
+        var requirement = new OperatorAccessRequirement(allowTenantApiKeyFallback);
+        var context = new AuthorizationHandlerContext(new[] { requirement }, user, resource: null);
+
+        await new OperatorAccessHandler().HandleAsync(context);
+        return context.HasSucceeded;
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Jwt_is_always_authorized(bool fallback)
+    {
+        (await Evaluate(AuthenticationConstants.AuthMethodJwt, fallback)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TenantApiKey_is_authorized_only_when_fallback_enabled()
+    {
+        (await Evaluate(AuthenticationConstants.AuthMethodTenantApiKey, allowTenantApiKeyFallback: true))
+            .Should().BeTrue("the dev/test escape hatch accepts the plaintext tenant key");
+    }
+
+    [Fact]
+    public async Task TenantApiKey_is_rejected_in_production()
+    {
+        (await Evaluate(AuthenticationConstants.AuthMethodTenantApiKey, allowTenantApiKeyFallback: false))
+            .Should().BeFalse("outside dev the plaintext tenant key must not authorize operator endpoints");
+    }
+
+    [Theory]
+    [InlineData(AuthenticationConstants.AuthMethodDeviceApiKey)]
+    [InlineData(AuthenticationConstants.AuthMethodCertificate)]
+    public async Task Device_credentials_are_never_authorized(string deviceAuthMethod)
+    {
+        (await Evaluate(deviceAuthMethod, allowTenantApiKeyFallback: true)).Should().BeFalse();
+        (await Evaluate(deviceAuthMethod, allowTenantApiKeyFallback: false)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Anonymous_or_untagged_principal_is_never_authorized()
+    {
+        (await Evaluate(authMethod: null, allowTenantApiKeyFallback: true)).Should().BeFalse();
+        (await Evaluate(authMethod: null, allowTenantApiKeyFallback: false)).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Operator/control-plane endpoints could be authorized with a **static, plaintext, config-backed tenant API key** — no rotation, expiry, or revocation, so a single leak grants full tenant control. This is the more severe half of the #390 auth review (#430 hardened the *anonymous* registration surface; this hardens the *authenticated operator* surface).

Operator endpoints now require a **Zitadel JWT**. The plaintext tenant key authorizes them **only outside Production** (a dev/test escape hatch); in Production only a JWT does. Device endpoints keep their hashed device key / mTLS path and are never operator-gated.

Closes #431

## Design

- **`OperatorAccess` authorization policy** (`src/Shared/SignalBeam.Shared.Infrastructure/Authentication/Authorization/`). Wired with `services.AddOperatorAuthorization(!builder.Environment.IsProduction())` in DeviceManager and BundleOrchestrator; applied per-endpoint / per-group with `.RequireAuthorization(AuthorizationPolicies.OperatorAccess)`.
- **Unambiguous `auth_method` claim.** The auth middlewares stamp `Jwt` / `TenantApiKey` / `DeviceApiKey` / `Certificate` on the principal, avoiding the `"ApiKey"` overload between device and tenant keys. `OperatorAccessHandler` decides on that claim — **fail-closed**: anything not explicitly `Jwt` (or `TenantApiKey` under the dev hatch) is denied, so a device credential can never reach an operator endpoint.
- The stamp is **authoritative**: any pre-existing `auth_method` claim (e.g. a Zitadel custom claim in the JWT payload) is stripped before the middleware value is written, so it can't be shadowed via `FindFirst`.

## Endpoint classification

**Operator (JWT-gated):** approve/reject devices, registration-token mint/list/revoke, device key generate/revoke, device/group/tag admin + reads, bundle CRUD & versions, bundle assignment, rollouts (unified + phased + status), certificate issue/revoke.

**Device (unchanged — never gated):** registration handshake (`POST /api/devices`, `registration-status`, `claim-key`), heartbeat, `state`, metrics report, `rotate-key`, `desired-state`, `sign-csr`. Verified against the edge agent's actual call list.

**IdentityManager:** already JWT-only (no tenant-key path) — no change needed.

## Escape hatch / ring-fencing

`AddOperatorAuthorization(allowTenantApiKeyFallback)` = `!IsProduction()`. In dev/test the plaintext tenant key still works (keeps local dev and the integration suite green without a running OIDC provider); in Production it's rejected with `403`. Documented in `.claude/rules/security.md` and the onboarding cookbook.

## Test plan

- ✅ **Unit** (`OperatorAccessHandlerTests`, `AuthMethodClaimStampTests`) — full authorization matrix (JWT always allowed, tenant key only under fallback, device/cert/anon always denied) + authoritative-stamp override.
- ✅ **Integration** (`OperatorEndpointAuthorizationTests`) — tenant key on an operator endpoint → `403` in a production-like config; token mint → `403`; tenant key allowed in dev config → `200`; handshake stays open even in production-like config → `201`; no creds → `401`.
- ✅ Full solution **Release build**, `dotnet format` clean, DeviceManager integration **83/83**, all other suites green.
- ✅ Reviewer **APPROVED** (two hardening findings addressed: authoritative `auth_method` stamp, `TryAddSingleton` handler dedup); verifier **PASS**.

## Follow-ups (out of scope, noted)

- `docs/features/authentication.md` and `docs/architecture/authentication-architecture.md` predate this policy — recommend a `/docs` pass (advisory; the onboarding cookbook is updated in this PR).
- Pre-existing `Console.WriteLine` JWT-debug logging in `DeviceManager/Program.cs` (from #422/#426) should be converted to `ILogger` — unrelated to this change.
- `IdentityManager` `/api/teams` `/api/users` use plain `.RequireAuthorization()` (any authenticated user); tightening to an operator/role policy is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)