### PR TITLE
add background prune of stale Pending devices

### DIFF
--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/appsettings.json
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/appsettings.json
@@ -21,6 +21,10 @@
     "CheckIntervalHours": 24,
     "WarningThresholdDays": 7
   },
+  "Registration": {
+    "PendingDeviceExpiryHours": 24,
+    "PruneIntervalHours": 6
+  },
   "Authentication": {
     "Jwt": {
       "Authority": "https://login.microsoftonline.com/your-tenant-id/v2.0",

--- a/src/DeviceManager/SignalBeam.DeviceManager.Host/appsettings.json
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Host/appsettings.json
@@ -22,6 +22,7 @@
     "WarningThresholdDays": 7
   },
   "Registration": {
+    "PruneEnabled": true,
     "PendingDeviceExpiryHours": 24,
     "PruneIntervalHours": 6
   },

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/BackgroundServices/PendingDevicePruneService.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/BackgroundServices/PendingDevicePruneService.cs
@@ -106,7 +106,8 @@ public class PendingDevicePruneOptions
     public double PruneIntervalHours { get; set; } = 6.0;
 
     /// <summary>
-    /// Enable or disable the background service. Default: true.
+    /// Enable or disable the background service. Default: true. Named PruneEnabled because the
+    /// section is shared with the Host's registration-handshake options.
     /// </summary>
-    public bool Enabled { get; set; } = true;
+    public bool PruneEnabled { get; set; } = true;
 }

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/BackgroundServices/PendingDevicePruneService.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/BackgroundServices/PendingDevicePruneService.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SignalBeam.DeviceManager.Infrastructure.Persistence;
+using SignalBeam.Domain.Enums;
+
+namespace SignalBeam.DeviceManager.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Periodically hard-deletes <see cref="DeviceRegistrationStatus.Pending"/> devices that never
+/// completed the registration handshake (#438). Deletes are idempotent, so overlapping runs from
+/// multiple instances are harmless.
+/// </summary>
+public class PendingDevicePruneService : BackgroundService
+{
+    private readonly ILogger<PendingDevicePruneService> _logger;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly PendingDevicePruneOptions _options;
+
+    public PendingDevicePruneService(
+        ILogger<PendingDevicePruneService> logger,
+        IServiceProvider serviceProvider,
+        IOptions<PendingDevicePruneOptions> options)
+    {
+        _logger = logger;
+        _serviceProvider = serviceProvider;
+        _options = options.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "Pending-device prune service started. Interval: {IntervalHours}h, TTL: {ExpiryHours}h",
+            _options.PruneIntervalHours,
+            _options.PendingDeviceExpiryHours);
+
+        // Delay-first: don't touch the database during host startup (races schema init in tests;
+        // nothing can be stale yet on a fresh boot anyway).
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromHours(_options.PruneIntervalHours), stoppingToken);
+
+            try
+            {
+                await PruneOnceAsync(stoppingToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(ex, "Error while pruning stale Pending devices");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs a single prune pass. Public so tests can trigger it deterministically.
+    /// </summary>
+    public async Task<int> PruneOnceAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DeviceDbContext>();
+
+        var cutoff = DateTimeOffset.UtcNow.AddHours(-_options.PendingDeviceExpiryHours);
+        var stopwatch = Stopwatch.StartNew();
+
+        var pruned = await context.Devices
+            .Where(d => d.RegistrationStatus == DeviceRegistrationStatus.Pending)
+            .Where(d => d.RegisteredAt < cutoff)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        stopwatch.Stop();
+
+        if (pruned > 0)
+        {
+            _logger.LogInformation(
+                "Pruned {PrunedCount} stale Pending devices registered before {Cutoff} in {DurationMs}ms",
+                pruned, cutoff, stopwatch.ElapsedMilliseconds);
+        }
+        else
+        {
+            _logger.LogDebug("No stale Pending devices to prune (cutoff {Cutoff})", cutoff);
+        }
+
+        return pruned;
+    }
+}
+
+/// <summary>
+/// Options for pruning stale Pending devices. Bound from the <c>Registration</c> section
+/// (shared with the registration handshake options).
+/// </summary>
+public class PendingDevicePruneOptions
+{
+    public const string SectionName = "Registration";
+
+    /// <summary>
+    /// A Pending device older than this is considered abandoned and deleted. Default: 24h.
+    /// </summary>
+    public double PendingDeviceExpiryHours { get; set; } = 24.0;
+
+    /// <summary>
+    /// How often the prune pass runs. Default: every 6h.
+    /// </summary>
+    public double PruneIntervalHours { get; set; } = 6.0;
+
+    /// <summary>
+    /// Enable or disable the background service. Default: true.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+}

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/DependencyInjection.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/DependencyInjection.cs
@@ -179,6 +179,19 @@ public static class DependencyInjection
             services.AddHostedService<CertificateExpirationCheckService>();
         }
 
+        // Register pending-device prune service if enabled
+        services.Configure<PendingDevicePruneOptions>(
+            configuration.GetSection(PendingDevicePruneOptions.SectionName));
+
+        var prunePendingOptions = configuration
+            .GetSection(PendingDevicePruneOptions.SectionName)
+            .Get<PendingDevicePruneOptions>() ?? new PendingDevicePruneOptions();
+
+        if (prunePendingOptions.Enabled)
+        {
+            services.AddHostedService<PendingDevicePruneService>();
+        }
+
         return services;
     }
 }

--- a/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/DependencyInjection.cs
+++ b/src/DeviceManager/SignalBeam.DeviceManager.Infrastructure/DependencyInjection.cs
@@ -187,7 +187,7 @@ public static class DependencyInjection
             .GetSection(PendingDevicePruneOptions.SectionName)
             .Get<PendingDevicePruneOptions>() ?? new PendingDevicePruneOptions();
 
-        if (prunePendingOptions.Enabled)
+        if (prunePendingOptions.PruneEnabled)
         {
             services.AddHostedService<PendingDevicePruneService>();
         }

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/PendingDevicePruneTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/PendingDevicePruneTests.cs
@@ -63,9 +63,8 @@ public class PendingDevicePruneTests : IClassFixture<DeviceManagerWebApplication
         var stale1 = await SeedDeviceAsync(DateTimeOffset.UtcNow.AddHours(-48));
         var stale2 = await SeedDeviceAsync(DateTimeOffset.UtcNow.AddHours(-25));
 
-        var pruned = await CreateService(expiryHours: 24).PruneOnceAsync(CancellationToken.None);
+        await CreateService(expiryHours: 24).PruneOnceAsync(CancellationToken.None);
 
-        pruned.Should().BeGreaterThanOrEqualTo(2);
         (await DeviceExistsAsync(stale1)).Should().BeFalse();
         (await DeviceExistsAsync(stale2)).Should().BeFalse();
     }

--- a/tests/SignalBeam.DeviceManager.Tests.Integration/PendingDevicePruneTests.cs
+++ b/tests/SignalBeam.DeviceManager.Tests.Integration/PendingDevicePruneTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SignalBeam.DeviceManager.Infrastructure.BackgroundServices;
+using SignalBeam.DeviceManager.Infrastructure.Persistence;
+using SignalBeam.DeviceManager.Tests.Integration.Infrastructure;
+using SignalBeam.Domain.Entities;
+using SignalBeam.Domain.Enums;
+using SignalBeam.Domain.ValueObjects;
+
+namespace SignalBeam.DeviceManager.Tests.Integration;
+
+/// <summary>
+/// Verifies the stale-Pending prune (#438): abandoned Pending devices past the TTL are hard-deleted;
+/// recent Pending devices and non-Pending devices survive.
+/// </summary>
+public class PendingDevicePruneTests : IClassFixture<DeviceManagerWebApplicationFactory>
+{
+    private readonly DeviceManagerWebApplicationFactory _factory;
+
+    public PendingDevicePruneTests(DeviceManagerWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private PendingDevicePruneService CreateService(double expiryHours = 24) =>
+        new(
+            NullLogger<PendingDevicePruneService>.Instance,
+            _factory.Services,
+            Options.Create(new PendingDevicePruneOptions { PendingDeviceExpiryHours = expiryHours }));
+
+    private async Task<DeviceId> SeedDeviceAsync(DateTimeOffset registeredAt, bool approved = false)
+    {
+        var device = Device.Register(
+            DeviceId.New(),
+            new TenantId(_factory.DefaultTenantId),
+            $"prune-test-{Guid.NewGuid():N}",
+            registeredAt);
+
+        if (approved)
+        {
+            device.ApproveRegistration(registeredAt);
+        }
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DeviceDbContext>();
+        context.Devices.Add(device);
+        await context.SaveChangesAsync();
+        return device.Id;
+    }
+
+    private async Task<bool> DeviceExistsAsync(DeviceId deviceId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DeviceDbContext>();
+        return await context.Devices.AnyAsync(d => d.Id == deviceId);
+    }
+
+    [Fact]
+    public async Task PruneOnce_DeletesPendingDevicesOlderThanTtl()
+    {
+        var stale1 = await SeedDeviceAsync(DateTimeOffset.UtcNow.AddHours(-48));
+        var stale2 = await SeedDeviceAsync(DateTimeOffset.UtcNow.AddHours(-25));
+
+        var pruned = await CreateService(expiryHours: 24).PruneOnceAsync(CancellationToken.None);
+
+        pruned.Should().BeGreaterThanOrEqualTo(2);
+        (await DeviceExistsAsync(stale1)).Should().BeFalse();
+        (await DeviceExistsAsync(stale2)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PruneOnce_KeepsPendingDevicesWithinTtl()
+    {
+        var fresh = await SeedDeviceAsync(DateTimeOffset.UtcNow.AddHours(-1));
+
+        await CreateService(expiryHours: 24).PruneOnceAsync(CancellationToken.None);
+
+        (await DeviceExistsAsync(fresh)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PruneOnce_NeverDeletesApprovedDevices()
+    {
+        var oldApproved = await SeedDeviceAsync(DateTimeOffset.UtcNow.AddDays(-30), approved: true);
+
+        await CreateService(expiryHours: 24).PruneOnceAsync(CancellationToken.None);
+
+        (await DeviceExistsAsync(oldApproved)).Should().BeTrue();
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DeviceDbContext>();
+        var device = await context.Devices.SingleAsync(d => d.Id == oldApproved);
+        device.RegistrationStatus.Should().Be(DeviceRegistrationStatus.Approved);
+    }
+}


### PR DESCRIPTION
## Summary

`Pending` devices that never complete the registration handshake currently sit in the database forever — exactly the junk rows a registration flood would leave behind. This adds a periodic background prune in DeviceManager that hard-deletes them once they age past a TTL.

Closes #438. Also completes the third and final acceptance item of #430 (rate-limit and opt-in token landed in #432), so closes #430.

## Design

- `PendingDevicePruneService` (`BackgroundService` in `DeviceManager.Infrastructure/BackgroundServices/`), registered via the existing enabled-gated hosted-service pattern.
- Set-based `ExecuteDeleteAsync` on `RegistrationStatus == Pending && RegisteredAt < cutoff` — no entities loaded, idempotent across concurrent instances (no distributed lock needed).
- **Delay-first loop**: the first pass runs one interval after startup, so the service never touches the database during host startup (this raced schema init in the integration-test factory; nothing can be stale on a fresh boot anyway).
- One structured log line per run (count, cutoff, duration); zero-result runs log at Debug.
- Config under the `Registration` section: `PruneEnabled` (default true), `PendingDeviceExpiryHours` (default 24), `PruneIntervalHours` (default 6). The enable flag is named `PruneEnabled` to avoid property-name collisions with the Host's registration options bound to the same section.
- **No migration** — the query keys on the existing `registered_at` column; no FK constraints reference `devices`, so the hard delete is safe.

## Test plan

- ✅ 3 integration tests (`PendingDevicePruneTests`): stale Pending devices (25h/48h old) deleted; 1h-old Pending survives; 30-day-old Approved device untouched and still `Approved`. Tests call `PruneOnceAsync` directly for determinism.
- ✅ Full solution Release build, `dotnet format` clean, DeviceManager integration 86/86, all other suites green.
- ✅ Reviewer PASS after fixes (renamed enable flag, dropped redundant count assertion); verifier PASS 6/6 criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)