### PR TITLE
make TelemetryProcessor NATS services reconnect instead of dying

### DIFF
--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Host/Program.cs
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Host/Program.cs
@@ -19,10 +19,10 @@ builder.Host.UseSerilog((context, configuration) =>
 builder.AddServiceDefaults();
 
 // A broker outage must not take down the whole service. The NATS background
-// services (consumer + SSE bridge) throw a fatal exception when NATS is
-// unreachable; with the default StopHost behavior that crashes the host and the
-// container crash-loops. Ignore lets the host stay up (serving HTTP + health)
-// while NATS-dependent features degrade until connectivity is restored.
+// services (consumer + SSE bridge) retry with backoff and recover on their own
+// (#387); Ignore remains as a guard so an unexpected fatal exception in any
+// other background service degrades that feature instead of crash-looping the
+// host (which serves HTTP + health).
 builder.Services.Configure<HostOptions>(options =>
     options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
 

--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/DependencyInjection.cs
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/DependencyInjection.cs
@@ -92,7 +92,11 @@ public static class DependencyInjection
             {
                 Url = natsUrl,
                 Name = "TelemetryProcessor",
-                ConnectTimeout = TimeSpan.FromSeconds(5)
+                ConnectTimeout = TimeSpan.FromSeconds(5),
+                MaxReconnectRetry = -1, // Unlimited reconnect attempts
+                ReconnectWaitMin = TimeSpan.FromSeconds(2),
+                ReconnectWaitMax = TimeSpan.FromSeconds(30), // Exponential backoff cap
+                ReconnectJitter = TimeSpan.FromMilliseconds(500)
             };
 
             logger.LogInformation("Connecting to NATS at {NatsUrl}", natsUrl);

--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Messaging/NatsConsumerService.cs
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Messaging/NatsConsumerService.cs
@@ -17,6 +17,9 @@ namespace SignalBeam.TelemetryProcessor.Infrastructure.Messaging;
 /// </summary>
 public class NatsConsumerService : BackgroundService
 {
+    private static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(1);
+
     private readonly ILogger<NatsConsumerService> _logger;
     private readonly NatsConnection _connection;
     private readonly INatsJSContext _jetStreamContext;
@@ -43,28 +46,43 @@ public class NatsConsumerService : BackgroundService
 
         try
         {
-            // Ensure streams exist
-            await EnsureStreamsExistAsync(stoppingToken);
+            // Retry until NATS is reachable — the service must survive a broker
+            // outage at startup and recover without a redeploy (#387).
+            var delay = InitialRetryDelay;
+            while (true)
+            {
+                try
+                {
+                    await EnsureStreamsExistAsync(stoppingToken);
+                    break;
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Failed to ensure JetStream streams (NATS may be unavailable); retrying in {DelaySeconds}s",
+                        delay.TotalSeconds);
+                    await Task.Delay(delay, stoppingToken);
+                    delay = Grow(delay);
+                }
+            }
 
-            // Start consuming device metrics
+            // Each consumer is self-healing; these only complete on cancellation.
             var metricsTask = ConsumeDeviceMetricsAsync(stoppingToken);
-
-            // Start consuming device heartbeats
             var heartbeatsTask = ConsumeDeviceHeartbeatsAsync(stoppingToken);
-
-            // Wait for both consumers to complete (which should be never unless cancellation is requested)
             await Task.WhenAll(metricsTask, heartbeatsTask);
         }
         catch (OperationCanceledException)
         {
             _logger.LogInformation("NATS Consumer Service stopping due to cancellation...");
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Fatal error in NATS Consumer Service");
-            throw;
-        }
     }
+
+    private static TimeSpan Grow(TimeSpan delay) =>
+        delay * 2 > MaxRetryDelay ? MaxRetryDelay : delay * 2;
 
     private async Task EnsureStreamsExistAsync(CancellationToken cancellationToken)
     {
@@ -121,154 +139,123 @@ public class NatsConsumerService : BackgroundService
         }
     }
 
-    private async Task ConsumeDeviceMetricsAsync(CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Starting Device Metrics consumer...");
-
-        var consumer = await _jetStreamContext.CreateOrUpdateConsumerAsync(
+    private Task ConsumeDeviceMetricsAsync(CancellationToken cancellationToken) =>
+        ConsumeLoopAsync<DeviceMetricsMessage>(
             _natsOptions.Streams.DeviceMetrics,
-            new ConsumerConfig
-            {
-                Name = "telemetry-processor-metrics",
-                DurableName = "telemetry-processor-metrics",
-                AckPolicy = ConsumerConfigAckPolicy.Explicit,
-                AckWait = TimeSpan.FromSeconds(30),
-                MaxDeliver = 3,
-                FilterSubject = _natsOptions.Subjects.DeviceMetrics
-            },
+            "telemetry-processor-metrics",
+            _natsOptions.Subjects.DeviceMetrics,
+            "Device Metrics",
+            (scope, message, token) => scope.ServiceProvider
+                .GetRequiredService<DeviceMetricsMessageHandler>()
+                .Handle(message, token),
             cancellationToken);
 
-        _logger.LogInformation("Device Metrics consumer created, starting message processing...");
-
-        // Consume messages in a loop
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                // Fetch and process messages
-                await foreach (var msg in consumer.FetchAsync<byte[]>(
-                    new NatsJSFetchOpts { MaxMsgs = 10, Expires = TimeSpan.FromSeconds(5) },
-                    serializer: default,
-                    cancellationToken))
-                {
-                    try
-                    {
-                        // Deserialize message
-                        var message = JsonSerializer.Deserialize<DeviceMetricsMessage>(msg.Data);
-                        if (message == null)
-                        {
-                            _logger.LogWarning("Received null metrics message, skipping");
-                            await msg.AckAsync(cancellationToken: cancellationToken);
-                            continue;
-                        }
-
-                        // Create scope to resolve scoped handler
-                        using (var scope = _scopeFactory.CreateScope())
-                        {
-                            var handler = scope.ServiceProvider.GetRequiredService<DeviceMetricsMessageHandler>();
-                            await handler.Handle(message, cancellationToken);
-                        }
-
-                        // Acknowledge successful processing
-                        await msg.AckAsync(cancellationToken: cancellationToken);
-                    }
-                    catch (JsonException ex)
-                    {
-                        _logger.LogError(ex, "Failed to deserialize metrics message");
-                        await msg.AckAsync(cancellationToken: cancellationToken); // Ack to skip bad message
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Error processing metrics message");
-                        await msg.NakAsync(delay: TimeSpan.FromSeconds(5), cancellationToken: cancellationToken);
-                    }
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogInformation("Device Metrics consumer cancelled");
-                break;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error in Device Metrics consumer loop, retrying...");
-                await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
-            }
-        }
-    }
-
-    private async Task ConsumeDeviceHeartbeatsAsync(CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Starting Device Heartbeats consumer...");
-
-        var consumer = await _jetStreamContext.CreateOrUpdateConsumerAsync(
+    private Task ConsumeDeviceHeartbeatsAsync(CancellationToken cancellationToken) =>
+        ConsumeLoopAsync<DeviceHeartbeatMessage>(
             _natsOptions.Streams.DeviceHeartbeats,
-            new ConsumerConfig
-            {
-                Name = "telemetry-processor-heartbeats",
-                DurableName = "telemetry-processor-heartbeats",
-                AckPolicy = ConsumerConfigAckPolicy.Explicit,
-                AckWait = TimeSpan.FromSeconds(30),
-                MaxDeliver = 3,
-                FilterSubject = _natsOptions.Subjects.DeviceHeartbeats
-            },
+            "telemetry-processor-heartbeats",
+            _natsOptions.Subjects.DeviceHeartbeats,
+            "Device Heartbeats",
+            (scope, message, token) => scope.ServiceProvider
+                .GetRequiredService<DeviceHeartbeatMessageHandler>()
+                .Handle(message, token),
             cancellationToken);
 
-        _logger.LogInformation("Device Heartbeats consumer created, starting message processing...");
+    /// <summary>
+    /// Self-healing consume loop: the JetStream consumer is (re)created inside the
+    /// retry loop so a broker outage recovers without a redeploy (#387).
+    /// </summary>
+    private async Task ConsumeLoopAsync<TMessage>(
+        string streamName,
+        string consumerName,
+        string filterSubject,
+        string description,
+        Func<IServiceScope, TMessage, CancellationToken, Task> handleAsync,
+        CancellationToken cancellationToken)
+        where TMessage : class
+    {
+        _logger.LogInformation("Starting {Description} consumer...", description);
 
-        // Consume messages in a loop
+        var delay = InitialRetryDelay;
         while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
-                // Fetch and process messages
-                await foreach (var msg in consumer.FetchAsync<byte[]>(
-                    new NatsJSFetchOpts { MaxMsgs = 10, Expires = TimeSpan.FromSeconds(5) },
-                    serializer: default,
-                    cancellationToken))
+                var consumer = await _jetStreamContext.CreateOrUpdateConsumerAsync(
+                    streamName,
+                    new ConsumerConfig
+                    {
+                        Name = consumerName,
+                        DurableName = consumerName,
+                        AckPolicy = ConsumerConfigAckPolicy.Explicit,
+                        AckWait = TimeSpan.FromSeconds(30),
+                        MaxDeliver = 3,
+                        FilterSubject = filterSubject
+                    },
+                    cancellationToken);
+
+                _logger.LogInformation("{Description} consumer created, starting message processing...", description);
+                delay = InitialRetryDelay;
+
+                while (!cancellationToken.IsCancellationRequested)
                 {
-                    try
+                    // Fetch and process messages
+                    await foreach (var msg in consumer.FetchAsync<byte[]>(
+                        new NatsJSFetchOpts { MaxMsgs = 10, Expires = TimeSpan.FromSeconds(5) },
+                        serializer: default,
+                        cancellationToken))
                     {
-                        // Deserialize message
-                        var message = JsonSerializer.Deserialize<DeviceHeartbeatMessage>(msg.Data);
-                        if (message == null)
+                        try
                         {
-                            _logger.LogWarning("Received null heartbeat message, skipping");
+                            var message = JsonSerializer.Deserialize<TMessage>(msg.Data);
+                            if (message == null)
+                            {
+                                _logger.LogWarning("Received null {Description} message, skipping", description);
+                                await msg.AckAsync(cancellationToken: cancellationToken);
+                                continue;
+                            }
+
+                            // Create scope to resolve scoped handler
+                            using (var scope = _scopeFactory.CreateScope())
+                            {
+                                await handleAsync(scope, message, cancellationToken);
+                            }
+
+                            // Acknowledge successful processing
                             await msg.AckAsync(cancellationToken: cancellationToken);
-                            continue;
                         }
-
-                        // Create scope to resolve scoped handler
-                        using (var scope = _scopeFactory.CreateScope())
+                        catch (JsonException ex)
                         {
-                            var handler = scope.ServiceProvider.GetRequiredService<DeviceHeartbeatMessageHandler>();
-                            await handler.Handle(message, cancellationToken);
+                            _logger.LogError(ex, "Failed to deserialize {Description} message", description);
+                            await msg.AckAsync(cancellationToken: cancellationToken); // Ack to skip bad message
                         }
-
-                        // Acknowledge successful processing
-                        await msg.AckAsync(cancellationToken: cancellationToken);
-                    }
-                    catch (JsonException ex)
-                    {
-                        _logger.LogError(ex, "Failed to deserialize heartbeat message");
-                        await msg.AckAsync(cancellationToken: cancellationToken); // Ack to skip bad message
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Error processing heartbeat message");
-                        await msg.NakAsync(delay: TimeSpan.FromSeconds(5), cancellationToken: cancellationToken);
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Error processing {Description} message", description);
+                            await msg.NakAsync(delay: TimeSpan.FromSeconds(5), cancellationToken: cancellationToken);
+                        }
                     }
                 }
             }
             catch (OperationCanceledException)
             {
-                _logger.LogInformation("Device Heartbeats consumer cancelled");
+                _logger.LogInformation("{Description} consumer cancelled", description);
                 break;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in Device Heartbeats consumer loop, retrying...");
-                await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+                _logger.LogWarning(ex,
+                    "{Description} consumer failed (NATS may be unavailable); recreating consumer in {DelaySeconds}s",
+                    description, delay.TotalSeconds);
+                try
+                {
+                    await Task.Delay(delay, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                delay = Grow(delay);
             }
         }
     }

--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Messaging/NatsConsumerService.cs
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Messaging/NatsConsumerService.cs
@@ -91,7 +91,7 @@ public class NatsConsumerService : BackgroundService
         // Ensure DEVICE_METRICS stream exists
         try
         {
-            var metricsStream = await _jetStreamContext.GetStreamAsync(
+            _ = await _jetStreamContext.GetStreamAsync(
                 _natsOptions.Streams.DeviceMetrics);
 
             _logger.LogInformation("Stream {StreamName} already exists", _natsOptions.Streams.DeviceMetrics);
@@ -116,7 +116,7 @@ public class NatsConsumerService : BackgroundService
         // Ensure DEVICE_HEARTBEATS stream exists
         try
         {
-            var heartbeatsStream = await _jetStreamContext.GetStreamAsync(
+            _ = await _jetStreamContext.GetStreamAsync(
                 _natsOptions.Streams.DeviceHeartbeats);
 
             _logger.LogInformation("Stream {StreamName} already exists", _natsOptions.Streams.DeviceHeartbeats);

--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Streaming/NatsSseBridgeService.cs
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Streaming/NatsSseBridgeService.cs
@@ -29,40 +29,62 @@ public class NatsSseBridgeService : BackgroundService
         _connectionManager = connectionManager;
     }
 
+    private static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(1);
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("NATS SSE Bridge starting, subscribing to {Subject}", MetricsSubject);
 
-        try
+        // Resubscribe with backoff instead of dying permanently, so the bridge
+        // recovers when NATS returns after an outage (#387).
+        var delay = InitialRetryDelay;
+        while (!stoppingToken.IsCancellationRequested)
         {
-            await foreach (var msg in _connection.SubscribeAsync<byte[]>(MetricsSubject, cancellationToken: stoppingToken))
+            try
             {
-                try
+                await foreach (var msg in _connection.SubscribeAsync<byte[]>(MetricsSubject, cancellationToken: stoppingToken))
                 {
-                    if (msg.Data is null)
-                        continue;
+                    delay = InitialRetryDelay;
 
-                    var message = JsonSerializer.Deserialize<DeviceMetricsMessage>(msg.Data);
-                    if (message is null)
-                        continue;
+                    try
+                    {
+                        if (msg.Data is null)
+                            continue;
 
-                    var deviceId = message.DeviceId.ToString();
-                    _connectionManager.Publish(deviceId, message);
-                }
-                catch (JsonException ex)
-                {
-                    _logger.LogWarning(ex, "Failed to deserialize metrics message for SSE bridge");
+                        var message = JsonSerializer.Deserialize<DeviceMetricsMessage>(msg.Data);
+                        if (message is null)
+                            continue;
+
+                        var deviceId = message.DeviceId.ToString();
+                        _connectionManager.Publish(deviceId, message);
+                    }
+                    catch (JsonException ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to deserialize metrics message for SSE bridge");
+                    }
                 }
             }
-        }
-        catch (OperationCanceledException)
-        {
-            _logger.LogInformation("NATS SSE Bridge stopping due to cancellation");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Fatal error in NATS SSE Bridge");
-            throw;
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("NATS SSE Bridge stopping due to cancellation");
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "NATS SSE Bridge subscription failed (NATS may be unavailable); resubscribing in {DelaySeconds}s",
+                    delay.TotalSeconds);
+                try
+                {
+                    await Task.Delay(delay, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                delay = delay * 2 > MaxRetryDelay ? MaxRetryDelay : delay * 2;
+            }
         }
     }
 }

--- a/tests/SignalBeam.TelemetryProcessor.Tests.Integration/NatsReconnectTests.cs
+++ b/tests/SignalBeam.TelemetryProcessor.Tests.Integration/NatsReconnectTests.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using SignalBeam.TelemetryProcessor.Application.MessageHandlers;
+using SignalBeam.TelemetryProcessor.Infrastructure.Messaging;
+using SignalBeam.TelemetryProcessor.Infrastructure.Messaging.Options;
+using SignalBeam.TelemetryProcessor.Infrastructure.Streaming;
+
+namespace SignalBeam.TelemetryProcessor.Tests.Integration;
+
+/// <summary>
+/// Verifies #387: the NATS background services survive a broker outage at startup
+/// and recover on their own once NATS becomes reachable — no redeploy needed.
+/// Each test picks a free host port so NATS can be started *after* the service.
+/// </summary>
+public class NatsReconnectTests
+{
+    private static readonly TimeSpan RecoveryTimeout = TimeSpan.FromSeconds(120);
+
+    [Fact]
+    public async Task NatsConsumerService_WhenNatsIsDownAtStartup_KeepsRetryingWithoutCrashing()
+    {
+        var port = GetFreePort();
+        await using var connection = CreateConnection(port);
+        var service = CreateConsumerService(connection);
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Long enough to cover the initial failure and at least one retry.
+        await Task.Delay(TimeSpan.FromSeconds(8));
+
+        service.ExecuteTask.Should().NotBeNull();
+        service.ExecuteTask!.IsCompleted.Should().BeFalse(
+            "the service should keep retrying while NATS is down instead of dying");
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task NatsConsumerService_WhenNatsComesUpAfterOutage_CreatesStreamsAndConsumers()
+    {
+        var port = GetFreePort();
+        await using var connection = CreateConnection(port);
+        var service = CreateConsumerService(connection);
+
+        // Start with NATS down so the service enters its retry loop.
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        await using var nats = BuildNatsContainer(port);
+        await nats.StartAsync();
+
+        // The service should now create the streams and durable consumers.
+        await using var verifyConnection = CreateConnection(port);
+        var verifyJs = new NatsJSContext(verifyConnection);
+
+        using var cts = new CancellationTokenSource(RecoveryTimeout);
+        var consumerNames = new[]
+        {
+            ("DEVICE_METRICS", "telemetry-processor-metrics"),
+            ("DEVICE_HEARTBEATS", "telemetry-processor-heartbeats")
+        };
+
+        foreach (var (stream, consumerName) in consumerNames)
+        {
+            var found = false;
+            while (!found)
+            {
+                cts.Token.IsCancellationRequested.Should().BeFalse(
+                    $"consumer {consumerName} should be (re)created within {RecoveryTimeout.TotalSeconds}s of NATS coming up");
+                try
+                {
+                    await verifyJs.GetConsumerAsync(stream, consumerName, cts.Token);
+                    found = true;
+                }
+                catch (Exception)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+                }
+            }
+        }
+
+        service.ExecuteTask!.IsCompleted.Should().BeFalse("the consumers should be running, not completed");
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task NatsSseBridgeService_WhenNatsComesUpAfterOutage_ResumesFanOut()
+    {
+        var port = GetFreePort();
+        await using var connection = CreateConnection(port);
+        var connectionManager = new SseConnectionManager(NullLogger<SseConnectionManager>.Instance);
+        var service = new NatsSseBridgeService(
+            NullLogger<NatsSseBridgeService>.Instance, connection, connectionManager);
+
+        // Start with NATS down so the bridge enters its resubscribe loop.
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        await using var nats = BuildNatsContainer(port);
+        await nats.StartAsync();
+
+        var deviceId = Guid.NewGuid();
+        var reader = connectionManager.Subscribe(deviceId.ToString());
+        var message = new DeviceMetricsMessage(
+            deviceId, DateTimeOffset.UtcNow, 50.0, 60.0, 70.0, 3600, 3);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(message);
+
+        await using var publisher = CreateConnection(port);
+
+        // Publish repeatedly — the bridge may still be waiting out its backoff.
+        using var cts = new CancellationTokenSource(RecoveryTimeout);
+        DeviceMetricsMessage? received = null;
+        while (received is null && !cts.Token.IsCancellationRequested)
+        {
+            await publisher.PublishAsync(
+                $"signalbeam.telemetry.metrics.{deviceId}", payload, cancellationToken: cts.Token);
+
+            if (await WaitForMessageAsync(reader, TimeSpan.FromSeconds(2)) is { } msg)
+            {
+                received = msg;
+            }
+        }
+
+        received.Should().NotBeNull(
+            $"the SSE bridge should resubscribe and fan out messages within {RecoveryTimeout.TotalSeconds}s of NATS coming up");
+        received!.DeviceId.Should().Be(deviceId);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    private static async Task<DeviceMetricsMessage?> WaitForMessageAsync(
+        System.Threading.Channels.ChannelReader<DeviceMetricsMessage> reader, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        try
+        {
+            return await reader.ReadAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+    }
+
+    private static NatsConsumerService CreateConsumerService(NatsConnection connection)
+    {
+        var scopeFactory = new ServiceCollection()
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+
+        return new NatsConsumerService(
+            NullLogger<NatsConsumerService>.Instance,
+            connection,
+            new NatsJSContext(connection),
+            Microsoft.Extensions.Options.Options.Create(new NatsOptions()),
+            scopeFactory);
+    }
+
+    private static NatsConnection CreateConnection(int port) =>
+        new(new NatsOpts
+        {
+            Url = $"nats://127.0.0.1:{port}",
+            ConnectTimeout = TimeSpan.FromSeconds(2),
+            MaxReconnectRetry = -1,
+            ReconnectWaitMin = TimeSpan.FromSeconds(1),
+            ReconnectWaitMax = TimeSpan.FromSeconds(5)
+        });
+
+    private static IContainer BuildNatsContainer(int hostPort) =>
+        new ContainerBuilder("nats:2.10-alpine")
+            .WithCommand("--jetstream")
+            .WithPortBinding(hostPort, 4222)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Server is ready"))
+            .Build();
+
+    private static int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/tests/SignalBeam.TelemetryProcessor.Tests.Integration/NatsReconnectTests.cs
+++ b/tests/SignalBeam.TelemetryProcessor.Tests.Integration/NatsReconnectTests.cs
@@ -21,6 +21,7 @@ namespace SignalBeam.TelemetryProcessor.Tests.Integration;
 /// and recover on their own once NATS becomes reachable — no redeploy needed.
 /// Each test picks a free host port so NATS can be started *after* the service.
 /// </summary>
+[Trait("Category", "Integration")]
 public class NatsReconnectTests
 {
     private static readonly TimeSpan RecoveryTimeout = TimeSpan.FromSeconds(120);
@@ -28,7 +29,8 @@ public class NatsReconnectTests
     [Fact]
     public async Task NatsConsumerService_WhenNatsIsDownAtStartup_KeepsRetryingWithoutCrashing()
     {
-        var port = GetFreePort();
+        using var reservedPort = new ReservedPort();
+        var port = reservedPort.Port;
         await using var connection = CreateConnection(port);
         var service = CreateConsumerService(connection);
 
@@ -47,7 +49,8 @@ public class NatsReconnectTests
     [Fact]
     public async Task NatsConsumerService_WhenNatsComesUpAfterOutage_CreatesStreamsAndConsumers()
     {
-        var port = GetFreePort();
+        using var reservedPort = new ReservedPort();
+        var port = reservedPort.Port;
         await using var connection = CreateConnection(port);
         var service = CreateConsumerService(connection);
 
@@ -56,6 +59,7 @@ public class NatsReconnectTests
         await Task.Delay(TimeSpan.FromSeconds(2));
 
         await using var nats = BuildNatsContainer(port);
+        reservedPort.Release();
         await nats.StartAsync();
 
         // The service should now create the streams and durable consumers.
@@ -96,7 +100,8 @@ public class NatsReconnectTests
     [Fact]
     public async Task NatsSseBridgeService_WhenNatsComesUpAfterOutage_ResumesFanOut()
     {
-        var port = GetFreePort();
+        using var reservedPort = new ReservedPort();
+        var port = reservedPort.Port;
         await using var connection = CreateConnection(port);
         var connectionManager = new SseConnectionManager(NullLogger<SseConnectionManager>.Instance);
         var service = new NatsSseBridgeService(
@@ -107,6 +112,7 @@ public class NatsReconnectTests
         await Task.Delay(TimeSpan.FromSeconds(2));
 
         await using var nats = BuildNatsContainer(port);
+        reservedPort.Release();
         await nats.StartAsync();
 
         var deviceId = Guid.NewGuid();
@@ -154,6 +160,8 @@ public class NatsReconnectTests
 
     private static NatsConsumerService CreateConsumerService(NatsConnection connection)
     {
+        // Intentionally empty: no messages are published in these tests, so the
+        // message handlers are never resolved — only connectivity is exercised.
         var scopeFactory = new ServiceCollection()
             .BuildServiceProvider()
             .GetRequiredService<IServiceScopeFactory>();
@@ -183,12 +191,29 @@ public class NatsReconnectTests
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Server is ready"))
             .Build();
 
-    private static int GetFreePort()
+    /// <summary>
+    /// Holds a bound listener so the chosen port can't be grabbed by another
+    /// process; released just before the NATS container binds it.
+    /// </summary>
+    private sealed class ReservedPort : IDisposable
     {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
+        private TcpListener? _listener;
+
+        public ReservedPort()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        }
+
+        public int Port { get; }
+
+        public void Release()
+        {
+            _listener?.Stop();
+            _listener = null;
+        }
+
+        public void Dispose() => Release();
     }
 }


### PR DESCRIPTION
## Summary
- `NatsConsumerService` and `NatsSseBridgeService` threw and stayed dead after a NATS outage — the host survived only via the `BackgroundServiceExceptionBehavior.Ignore` stopgap (PR #381), so consumers never recovered until a redeploy. Both services now retry with exponential backoff (5s → 1m cap): stream setup retries until NATS is reachable, the JetStream consumers are (re)created *inside* the retry loop, and the SSE bridge resubscribes.
- The two duplicated consume loops were folded into a generic `ConsumeLoopAsync<TMessage>`, which also fixes a latent bug: if one consumer faulted during creation while the other ran, `Task.WhenAll` hung forever with a silently dead consumer.
- The singleton `NatsOpts` now sets `MaxReconnectRetry = -1`, `ReconnectWaitMin/Max = 2s/30s`, `ReconnectJitter = 500ms` — mirroring EdgeAgent's existing pattern (it previously set only `ConnectTimeout = 5s`).
- New `NatsReconnectTests` use Testcontainers to start NATS on a pre-reserved port *after* the services, proving the acceptance scenario end-to-end: services keep retrying through a startup outage, then create their durable consumers / resume SSE fan-out once NATS comes up — no redeploy.

Closes #387

## Affected Services
TelemetryProcessor

## Changes
- **Domain:** No changes
- **Application:** No changes
- **Infrastructure:** Retry-with-backoff in `NatsConsumerService` (stream setup + self-healing `ConsumeLoopAsync<TMessage>`) and `NatsSseBridgeService` (resubscribe loop); `NatsOpts` reconnect tuning in `DependencyInjection.cs`
- **Endpoints:** No changes (Host `Program.cs`: only the `Ignore` stopgap comment updated — it stays as a guard for other background services)
- **Frontend:** No changes
- **Tests:** 3 new outage-recovery integration tests (`[Trait("Category","Integration")]`, port reserved via bound listener to avoid the ephemeral-port race)

## Notes
- The issue's "depends on the NATS transport decision (#382)" concerns which transport the deployed ACA environment uses; the reconnect behavior here is transport-agnostic, so #382 remains open independently.

## Test Plan
- [x] TelemetryProcessor integration tests: 16/16 (incl. 3 new reconnect tests, Testcontainers NATS)
- [x] TelemetryProcessor Infrastructure tests: 20/20
- [x] DeviceManager integration: 86/86; all unit suites green (357 tests)
- [x] `dotnet format --verify-no-changes` clean
- [x] No pending EF migrations
- [x] Verifier agent: 4/4 criteria MET; reviewer warnings all addressed (unused-var discards, port reservation, integration trait, DI comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRYwkthpxDJPwF5tam5Lqj