### PR TITLE
fix TelemetryProcessor migrations on Azure's apache-licensed TimescaleDB

### DIFF
--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Persistence/Migrations/20260707131911_InitialCreateWithTimescaleDB.cs
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Persistence/Migrations/20260707131911_InitialCreateWithTimescaleDB.cs
@@ -268,52 +268,38 @@ namespace SignalBeam.TelemetryProcessor.Infrastructure.Persistence.Migrations
                     if_not_exists => TRUE);
             ");
 
+            // Compression and retention policies are Timescale-License features.
+            // Azure PostgreSQL Flexible Server ships the Apache-2 edition, which
+            // rejects them with 0A000 — skip there, hypertables still apply.
             migrationBuilder.Sql(@"
-                ALTER TABLE telemetry_processor.device_heartbeats SET (
-                    timescaledb.compress,
-                    timescaledb.compress_segmentby = 'device_id',
-                    timescaledb.compress_orderby = 'timestamp DESC'
-                );
-            ");
-
-            migrationBuilder.Sql(@"
-                ALTER TABLE telemetry_processor.device_metrics SET (
-                    timescaledb.compress,
-                    timescaledb.compress_segmentby = 'device_id',
-                    timescaledb.compress_orderby = 'timestamp DESC'
-                );
-            ");
-
-            migrationBuilder.Sql(@"
-                ALTER TABLE telemetry_processor.device_health_scores SET (
-                    timescaledb.compress,
-                    timescaledb.compress_segmentby = 'device_id',
-                    timescaledb.compress_orderby = 'timestamp DESC'
-                );
-            ");
-
-            migrationBuilder.Sql(@"
-                SELECT add_compression_policy('telemetry_processor.device_heartbeats', INTERVAL '7 days', if_not_exists => TRUE);
-            ");
-
-            migrationBuilder.Sql(@"
-                SELECT add_compression_policy('telemetry_processor.device_metrics', INTERVAL '7 days', if_not_exists => TRUE);
-            ");
-
-            migrationBuilder.Sql(@"
-                SELECT add_compression_policy('telemetry_processor.device_health_scores', INTERVAL '7 days', if_not_exists => TRUE);
-            ");
-
-            migrationBuilder.Sql(@"
-                SELECT add_retention_policy('telemetry_processor.device_heartbeats', INTERVAL '90 days', if_not_exists => TRUE);
-            ");
-
-            migrationBuilder.Sql(@"
-                SELECT add_retention_policy('telemetry_processor.device_metrics', INTERVAL '90 days', if_not_exists => TRUE);
-            ");
-
-            migrationBuilder.Sql(@"
-                SELECT add_retention_policy('telemetry_processor.device_health_scores', INTERVAL '90 days', if_not_exists => TRUE);
+                DO $$
+                BEGIN
+                    IF current_setting('timescaledb.license', true) = 'timescale' THEN
+                        ALTER TABLE telemetry_processor.device_heartbeats SET (
+                            timescaledb.compress,
+                            timescaledb.compress_segmentby = 'device_id',
+                            timescaledb.compress_orderby = 'timestamp DESC'
+                        );
+                        ALTER TABLE telemetry_processor.device_metrics SET (
+                            timescaledb.compress,
+                            timescaledb.compress_segmentby = 'device_id',
+                            timescaledb.compress_orderby = 'timestamp DESC'
+                        );
+                        ALTER TABLE telemetry_processor.device_health_scores SET (
+                            timescaledb.compress,
+                            timescaledb.compress_segmentby = 'device_id',
+                            timescaledb.compress_orderby = 'timestamp DESC'
+                        );
+                        PERFORM add_compression_policy('telemetry_processor.device_heartbeats', INTERVAL '7 days', if_not_exists => TRUE);
+                        PERFORM add_compression_policy('telemetry_processor.device_metrics', INTERVAL '7 days', if_not_exists => TRUE);
+                        PERFORM add_compression_policy('telemetry_processor.device_health_scores', INTERVAL '7 days', if_not_exists => TRUE);
+                        PERFORM add_retention_policy('telemetry_processor.device_heartbeats', INTERVAL '90 days', if_not_exists => TRUE);
+                        PERFORM add_retention_policy('telemetry_processor.device_metrics', INTERVAL '90 days', if_not_exists => TRUE);
+                        PERFORM add_retention_policy('telemetry_processor.device_health_scores', INTERVAL '90 days', if_not_exists => TRUE);
+                    ELSE
+                        RAISE NOTICE 'timescaledb apache edition: skipping compression and retention policies';
+                    END IF;
+                END $$;
             ");
         }
 
@@ -321,12 +307,17 @@ namespace SignalBeam.TelemetryProcessor.Infrastructure.Persistence.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.Sql(@"
-                SELECT remove_retention_policy('telemetry_processor.device_heartbeats', if_exists => true);
-                SELECT remove_retention_policy('telemetry_processor.device_metrics', if_exists => true);
-                SELECT remove_retention_policy('telemetry_processor.device_health_scores', if_exists => true);
-                SELECT remove_compression_policy('telemetry_processor.device_heartbeats', if_exists => true);
-                SELECT remove_compression_policy('telemetry_processor.device_metrics', if_exists => true);
-                SELECT remove_compression_policy('telemetry_processor.device_health_scores', if_exists => true);
+                DO $$
+                BEGIN
+                    IF current_setting('timescaledb.license', true) = 'timescale' THEN
+                        PERFORM remove_retention_policy('telemetry_processor.device_heartbeats', if_exists => true);
+                        PERFORM remove_retention_policy('telemetry_processor.device_metrics', if_exists => true);
+                        PERFORM remove_retention_policy('telemetry_processor.device_health_scores', if_exists => true);
+                        PERFORM remove_compression_policy('telemetry_processor.device_heartbeats', if_exists => true);
+                        PERFORM remove_compression_policy('telemetry_processor.device_metrics', if_exists => true);
+                        PERFORM remove_compression_policy('telemetry_processor.device_health_scores', if_exists => true);
+                    END IF;
+                END $$;
             ");
 
             migrationBuilder.DropTable(

--- a/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Persistence/Migrations/20260707132525_AddContinuousAggregates.cs
+++ b/src/TelemetryProcessor/SignalBeam.TelemetryProcessor.Infrastructure/Persistence/Migrations/20260707132525_AddContinuousAggregates.cs
@@ -5,18 +5,20 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace SignalBeam.TelemetryProcessor.Infrastructure.Persistence.Migrations
 {
     /// <summary>
-    /// TimescaleDB continuous aggregates (hourly/daily rollups) queried by the
-    /// metrics and heartbeat repositories for dashboard reads.
+    /// Hourly/daily rollup views queried by the metrics and heartbeat repositories.
+    /// Plain SQL views rather than TimescaleDB continuous aggregates: Azure
+    /// PostgreSQL ships the Apache-2 edition, which rejects continuous aggregates
+    /// (0A000) at parse time — even behind IF NOT EXISTS — so a single portable
+    /// definition is used on every edition. Revisit materialized rollups when
+    /// query volume warrants it.
     /// </summary>
     public partial class AddContinuousAggregates : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            // Continuous aggregates cannot be created inside a transaction block
             migrationBuilder.Sql(@"
-                CREATE MATERIALIZED VIEW telemetry_processor.device_metrics_hourly
-                WITH (timescaledb.continuous) AS
+                CREATE VIEW telemetry_processor.device_metrics_hourly AS
                 SELECT
                     time_bucket('1 hour', timestamp) AS bucket,
                     device_id,
@@ -33,20 +35,11 @@ namespace SignalBeam.TelemetryProcessor.Infrastructure.Persistence.Migrations
                     AVG(running_containers) as avg_running_containers,
                     COUNT(*) as sample_count
                 FROM telemetry_processor.device_metrics
-                GROUP BY bucket, device_id
-                WITH NO DATA;
-            ", suppressTransaction: true);
+                GROUP BY bucket, device_id;
+            ");
 
             migrationBuilder.Sql(@"
-                SELECT add_continuous_aggregate_policy('telemetry_processor.device_metrics_hourly',
-                    start_offset => INTERVAL '3 hours',
-                    end_offset => INTERVAL '30 minutes',
-                    schedule_interval => INTERVAL '30 minutes');
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                CREATE MATERIALIZED VIEW telemetry_processor.device_metrics_daily
-                WITH (timescaledb.continuous) AS
+                CREATE VIEW telemetry_processor.device_metrics_daily AS
                 SELECT
                     time_bucket('1 day', timestamp) AS bucket,
                     device_id,
@@ -63,20 +56,11 @@ namespace SignalBeam.TelemetryProcessor.Infrastructure.Persistence.Migrations
                     AVG(running_containers) as avg_running_containers,
                     COUNT(*) as sample_count
                 FROM telemetry_processor.device_metrics
-                GROUP BY bucket, device_id
-                WITH NO DATA;
-            ", suppressTransaction: true);
+                GROUP BY bucket, device_id;
+            ");
 
             migrationBuilder.Sql(@"
-                SELECT add_continuous_aggregate_policy('telemetry_processor.device_metrics_daily',
-                    start_offset => INTERVAL '7 days',
-                    end_offset => INTERVAL '1 hour',
-                    schedule_interval => INTERVAL '2 hours');
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                CREATE MATERIALIZED VIEW telemetry_processor.device_heartbeats_hourly
-                WITH (timescaledb.continuous) AS
+                CREATE VIEW telemetry_processor.device_heartbeats_hourly AS
                 SELECT
                     time_bucket('1 hour', timestamp) AS bucket,
                     device_id,
@@ -84,59 +68,16 @@ namespace SignalBeam.TelemetryProcessor.Infrastructure.Persistence.Migrations
                     COUNT(*) as heartbeat_count,
                     COUNT(DISTINCT ip_address) as unique_ip_count
                 FROM telemetry_processor.device_heartbeats
-                GROUP BY bucket, device_id
-                WITH NO DATA;
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                SELECT add_continuous_aggregate_policy('telemetry_processor.device_heartbeats_hourly',
-                    start_offset => INTERVAL '3 hours',
-                    end_offset => INTERVAL '30 minutes',
-                    schedule_interval => INTERVAL '30 minutes');
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                CREATE INDEX ix_device_metrics_hourly_device_bucket
-                ON telemetry_processor.device_metrics_hourly (device_id, bucket DESC);
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                CREATE INDEX ix_device_metrics_daily_device_bucket
-                ON telemetry_processor.device_metrics_daily (device_id, bucket DESC);
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                CREATE INDEX ix_device_heartbeats_hourly_device_bucket
-                ON telemetry_processor.device_heartbeats_hourly (device_id, bucket DESC);
-            ", suppressTransaction: true);
+                GROUP BY bucket, device_id;
+            ");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql(@"
-                SELECT remove_continuous_aggregate_policy('telemetry_processor.device_metrics_hourly', if_exists => true);
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                SELECT remove_continuous_aggregate_policy('telemetry_processor.device_metrics_daily', if_exists => true);
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                SELECT remove_continuous_aggregate_policy('telemetry_processor.device_heartbeats_hourly', if_exists => true);
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                DROP MATERIALIZED VIEW IF EXISTS telemetry_processor.device_heartbeats_hourly CASCADE;
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                DROP MATERIALIZED VIEW IF EXISTS telemetry_processor.device_metrics_daily CASCADE;
-            ", suppressTransaction: true);
-
-            migrationBuilder.Sql(@"
-                DROP MATERIALIZED VIEW IF EXISTS telemetry_processor.device_metrics_hourly CASCADE;
-            ", suppressTransaction: true);
+            migrationBuilder.Sql("DROP VIEW IF EXISTS telemetry_processor.device_heartbeats_hourly CASCADE;");
+            migrationBuilder.Sql("DROP VIEW IF EXISTS telemetry_processor.device_metrics_daily CASCADE;");
+            migrationBuilder.Sql("DROP VIEW IF EXISTS telemetry_processor.device_metrics_hourly CASCADE;");
         }
     }
 }

--- a/tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests/Persistence/DeviceMetricsRepositoryTests.cs
+++ b/tests/SignalBeam.TelemetryProcessor.Infrastructure.Tests/Persistence/DeviceMetricsRepositoryTests.cs
@@ -229,10 +229,8 @@ public class DeviceMetricsRepositoryTests : IAsyncLifetime
         await _repository!.AddRangeAsync(metrics);
         await _repository.SaveChangesAsync();
 
-        // The aggregate is created WITH NO DATA and its refresh policy won't fire
-        // during the test, so materialize it explicitly.
-        await _context!.Database.ExecuteSqlRawAsync(
-            "CALL refresh_continuous_aggregate('telemetry_processor.device_metrics_hourly', NULL, NULL);");
+        // device_metrics_hourly is a plain SQL view (portable across TimescaleDB
+        // editions), so the inserted metrics are visible immediately.
 
         // Act
         var aggregates = await _repository.GetHourlyAggregatesAsync(

--- a/tests/SignalBeam.TelemetryProcessor.Tests.Integration/MigrationsApacheLicenseTests.cs
+++ b/tests/SignalBeam.TelemetryProcessor.Tests.Integration/MigrationsApacheLicenseTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SignalBeam.TelemetryProcessor.Infrastructure.Persistence;
+using Testcontainers.PostgreSql;
+
+namespace SignalBeam.TelemetryProcessor.Tests.Integration;
+
+/// <summary>
+/// Azure PostgreSQL Flexible Server ships the Apache-2 TimescaleDB edition, which
+/// rejects compression, retention policies, and continuous aggregates (0A000).
+/// These tests run the real migrations under that license to prove they degrade
+/// gracefully: hypertables apply, and the rollup relations exist as plain views.
+/// </summary>
+[Trait("Category", "Integration")]
+public class MigrationsApacheLicenseTests : IAsyncLifetime
+{
+    private PostgreSqlContainer? _container;
+    private TelemetryDbContext? _context;
+
+    public async Task InitializeAsync()
+    {
+        _container = new PostgreSqlBuilder("timescale/timescaledb:latest-pg16")
+            .WithDatabase("telemetry_apache_test")
+            .WithUsername("postgres")
+            .WithPassword("postgres")
+            .WithCommand("-c", "timescaledb.license=apache")
+            .Build();
+
+        await _container.StartAsync();
+
+        var options = new DbContextOptionsBuilder<TelemetryDbContext>()
+            .UseNpgsql(_container.GetConnectionString())
+            .Options;
+        _context = new TelemetryDbContext(options);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_context != null)
+        {
+            await _context.DisposeAsync();
+        }
+
+        if (_container != null)
+        {
+            await _container.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Migrations_UnderApacheLicense_ApplyCleanly_WithPlainViewRollups()
+    {
+        await _context!.Database.MigrateAsync();
+
+        // Hypertables are an Apache-edition feature and must exist.
+        var hypertables = await CountAsync(
+            "SELECT COUNT(*) FROM timescaledb_information.hypertables WHERE hypertable_schema = 'telemetry_processor'");
+        hypertables.Should().Be(3);
+
+        // The rollup relations must exist as plain views ('v'), not continuous aggregates.
+        var views = await CountAsync(@"
+            SELECT COUNT(*) FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'telemetry_processor'
+              AND c.relname IN ('device_metrics_hourly', 'device_metrics_daily', 'device_heartbeats_hourly')
+              AND c.relkind = 'v'");
+        views.Should().Be(3);
+
+        // And they must be queryable.
+        var rows = await CountAsync("SELECT COUNT(*) FROM telemetry_processor.device_metrics_hourly");
+        rows.Should().Be(0);
+    }
+
+    private async Task<long> CountAsync(string sql)
+    {
+        var connection = _context!.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+            await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt64(result);
+    }
+}


### PR DESCRIPTION
## Summary
- Rolling the #441 migrations onto ACA failed: the new TelemetryProcessor revision went `ActivationFailed` with `0A000: functionality not supported under the current "apache" license`. **Azure PostgreSQL Flexible Server ships TimescaleDB's Apache-2 edition** — no compression, no retention policies, no continuous aggregates. Our local `timescale/timescaledb` image runs the community edition, so tests never caught it.
- Compression + retention policies now run behind a `current_setting('timescaledb.license')` check (kept on community/TSL deployments, skipped on Apache with a NOTICE).
- Continuous aggregates are rejected by the Timescale DDL hook at parse time — even behind `IF NOT EXISTS` — so they cannot appear in portable migration SQL at all. The three rollup relations (`device_metrics_hourly`, `device_metrics_daily`, `device_heartbeats_hourly`) are now **plain SQL views on every edition**: identical shape, always fresh, no refresh machinery. Materialized rollups can return later as a runtime, license-aware optimization if query volume warrants it.
- New integration test runs the full migration chain under `-c timescaledb.license=apache` and asserts hypertables apply and the rollups exist as queryable views — the Azure path is now covered permanently.

Relates to #428 (follow-up deploy fix; found during #371 dogfooding).

## Affected Services
TelemetryProcessor

## Changes
- **Infrastructure:** license-guarded compression/retention in `InitialCreateWithTimescaleDB`; `AddContinuousAggregates` creates plain views; `Down()` paths updated
- **Tests:** new `MigrationsApacheLicenseTests` (apache-mode Testcontainer); hourly-aggregates repository test no longer calls `refresh_continuous_aggregate`

## Deployment Notes
- The failed ACA rollout left the database clean (the transactional migration body rolled back; only the idempotent `CREATE EXTENSION` persisted). Re-rolling TelemetryProcessor after this merge applies everything fresh.
- `shared_preload_libraries=timescaledb` is already applied + server restarted on `sb-psql-dev-neu`.

## Test Plan
- [x] `MigrationsApacheLicenseTests` green (apache edition: 3 hypertables, 3 plain views, queryable)
- [x] TelemetryProcessor integration 17/17 + Infrastructure 20/20 (community edition)
- [x] Build + `dotnet format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRYwkthpxDJPwF5tam5Lqj